### PR TITLE
Meeting command

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -245,11 +245,11 @@ Format: `meeting add c/CONTACT_INDEX m/MESSAGE d/START_DATETIME du/DURATION`
 * The index refers to the index number shown in the displayed contact list.
 * The index must be a positive integer 1, 2, 3, …​
 * The start datetime must be in the format `yyyy-MM-dd HH:mm`
-* The duration is specified in hours and must be a positive number (not necessarily an integer).
+* The duration is specified in minutes and must be a positive integer.
 
 Examples:
-* `meeting add c/2 t/Follow-up meeting s/2020-10-30 15:00 d/1` Adds a 1-hour long meeting titled `Follow-up meeting` with the 2nd contact in StonksBook that is scheduled for 30th October 2020 at 3PM.
-* `meeting add c/3 t/Call to finalise details s/2020-10-30 08:00 d/0.5` Adds a 30-minute long meeting titled `Call to finalise details` with the 3rd contact in StonksBook that is scheduled for 30th October 2020 at 8AM.
+* `meeting add c/2 t/Follow-up meeting s/2020-10-30 15:00 d/60` Adds a 1-hour long meeting titled `Follow-up meeting` with the 2nd contact in StonksBook that is scheduled for 30th October 2020 at 3PM.
+* `meeting add c/3 t/Call to finalise details s/2020-10-30 08:00 d/30` Adds a 30-minute long meeting titled `Call to finalise details` with the 3rd contact in StonksBook that is scheduled for 30th October 2020 at 8AM.
 
 #### Listing all meetings: `meeting list`
 

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -257,7 +257,7 @@ Shows a list of all meetings. By default, the list only shows upcoming meetings.
 
 <img src="images/meetingListMockup.png" alt="result for 'meeting list'" width="400px">
 
-Format: `meetings list [c/CONTACT_INDEX] [a/]`
+Format: `meeting list [c/CONTACT_INDEX] [a/]`
 
 * When an index is specified, the list will only show meetings associated with the contact at the specified index.
 * You can show all meetings, including those that have passed, by typing `a/`.

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -248,8 +248,8 @@ Format: `meeting add c/CONTACT_INDEX m/MESSAGE d/START_DATETIME du/DURATION`
 * The duration is specified in minutes and must be a positive integer.
 
 Examples:
-* `meeting add c/2 t/Follow-up meeting s/2020-10-30 15:00 d/60` Adds a 1-hour long meeting titled `Follow-up meeting` with the 2nd contact in StonksBook that is scheduled for 30th October 2020 at 3PM.
-* `meeting add c/3 t/Call to finalise details s/2020-10-30 08:00 d/30` Adds a 30-minute long meeting titled `Call to finalise details` with the 3rd contact in StonksBook that is scheduled for 30th October 2020 at 8AM.
+* `meeting add c/2 m/Follow-up meeting d/2020-10-30 15:00 du/60` Adds a 1-hour long meeting titled `Follow-up meeting` with the 2nd contact in StonksBook that is scheduled for 30th October 2020 at 3PM.
+* `meeting add c/3 m/Call to finalise details d/2020-10-30 08:00 du/30` Adds a 30-minute long meeting titled `Call to finalise details` with the 3rd contact in StonksBook that is scheduled for 30th October 2020 at 8AM.
 
 #### Listing all meetings: `meeting list`
 
@@ -369,7 +369,7 @@ Action | Format, Examples
 **Tag Edit** | `tag edit INDEX n/NAME` <br> e.g., `tag edit 1 n/family`
 **Tag Delete** | `tag delete INDEX` <br> e.g., `tag delete 1`
 **Tag Find** | `tag find INDEX [MODEL]` <br> e.g., `tag find 1 contact`
-**Meeting Add** | `meeting add c/CONTACT_INDEX t/TITLE s/START_DATETIME d/DURATION` <br> e.g., `meeting add 2 t/Follow-up meeting s/2020-10-30 15:00 d/1`
+**Meeting Add** | `meeting add c/CONTACT_INDEX m/TITLE d/START_DATETIME du/DURATION` <br> e.g., `meeting add 2 m/Follow-up meeting d/2020-10-30 15:00 du/60`
 **Meeting List** | `meeting list [c/CONTACT_INDEX] [a/]`
 **Meeting Delete** | `meeting delete INDEX` <br> e.g., `meeting delete 3`
 **Reminder Add** | `reminder add c/CONTACT_INDEX m/MESSAGE d/DATETIME` <br> e.g., `reminder add 2 m/Send follow-up email d/2020-10-30 15:00`

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -239,7 +239,7 @@ Examples:
 
 Adds a scheduled meeting with the specified contact in StonksBook.
 
-Format: `meeting add c/CONTACT_INDEX t/TITLE s/START_DATETIME d/DURATION`
+Format: `meeting add c/CONTACT_INDEX m/MESSAGE d/START_DATETIME du/DURATION`
 
 * Adds a scheduled meeting with the contact at the specified `CONTACT_INDEX`.
 * The index refers to the index number shown in the displayed contact list.

--- a/src/main/java/seedu/address/commons/core/Messages.java
+++ b/src/main/java/seedu/address/commons/core/Messages.java
@@ -13,4 +13,5 @@ public class Messages {
         "Dates should be specified in the format 'yyyy-MM-dd HH:mm'";
     public static final String MESSAGE_INVALID_REMINDER_DISPLAYED_INDEX = "The reminder index provided is invalid";
     public static final String MESSAGE_INVALID_TAG_DISPLAYED_INDEX = "The tag index provided is invalid";
+    public static final String MESSAGE_INVALID_MEETING_DISPLAYED_INDEX = "The meeting index provided is invalid";
 }

--- a/src/main/java/seedu/address/commons/core/Messages.java
+++ b/src/main/java/seedu/address/commons/core/Messages.java
@@ -10,7 +10,9 @@ public class Messages {
     public static final String MESSAGE_INVALID_PERSON_DISPLAYED_INDEX = "The person index provided is invalid";
     public static final String MESSAGE_PERSONS_LISTED_OVERVIEW = "%1$d persons listed!";
     public static final String MESSAGE_INVALID_DATETIME =
-        "Dates should be specified in the format 'yyyy-MM-dd HH:mm'";
+            "Dates should be specified in the format 'yyyy-MM-dd HH:mm'";
+    public static final String MESSAGE_INVALID_DURATION =
+            "Durations should be specified as a positive integer denoting the number of minutes.";
     public static final String MESSAGE_INVALID_REMINDER_DISPLAYED_INDEX = "The reminder index provided is invalid";
     public static final String MESSAGE_INVALID_TAG_DISPLAYED_INDEX = "The tag index provided is invalid";
     public static final String MESSAGE_INVALID_MEETING_DISPLAYED_INDEX = "The meeting index provided is invalid";

--- a/src/main/java/seedu/address/commons/enums/GroupEnum.java
+++ b/src/main/java/seedu/address/commons/enums/GroupEnum.java
@@ -4,4 +4,5 @@ public enum GroupEnum {
     CONTACT,
     TAG,
     REMINDER,
+    MEETING,
 }

--- a/src/main/java/seedu/address/logic/commands/meeting/AddCommand.java
+++ b/src/main/java/seedu/address/logic/commands/meeting/AddCommand.java
@@ -70,7 +70,7 @@ public class AddCommand extends Command {
     public CommandResult execute(Model model) throws CommandException {
         requireNonNull(model);
 
-        List<Person> lastShownList = model.getFilteredPersonList();
+        List<Person> lastShownList = model.getSortedPersonList();
 
         if (index.getZeroBased() >= lastShownList.size()) {
             throw new CommandException(Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);

--- a/src/main/java/seedu/address/logic/commands/meeting/AddCommand.java
+++ b/src/main/java/seedu/address/logic/commands/meeting/AddCommand.java
@@ -1,0 +1,109 @@
+package seedu.address.logic.commands.meeting;
+
+import static java.util.Objects.requireNonNull;
+import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_CONTACT;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_DATETIME;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_DURATION;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_MESSAGE;
+
+import java.time.Duration;
+import java.time.LocalDateTime;
+import java.util.List;
+
+import seedu.address.commons.core.Messages;
+import seedu.address.commons.core.index.Index;
+import seedu.address.logic.commands.Command;
+import seedu.address.logic.commands.CommandResult;
+import seedu.address.logic.commands.exceptions.CommandException;
+import seedu.address.model.Model;
+import seedu.address.model.meeting.Meeting;
+import seedu.address.model.person.Person;
+
+/**
+ * Adds a meeting associated with a contact to StonksBook.
+ */
+public class AddCommand extends Command {
+    public static final String COMMAND_WORD = "meeting add";
+
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Adds a scheduled meeting with the given duration "
+            + "that is associated with the specified contact. "
+            + "Parameters: "
+            + PREFIX_CONTACT + "CONTACT_INDEX (must be a positive integer) "
+            + PREFIX_MESSAGE + "MESSAGE "
+            + PREFIX_DATETIME + "START_DATETIME"
+            + PREFIX_DURATION + "DURATION\n"
+            + "Example: " + COMMAND_WORD + " "
+            + PREFIX_CONTACT + "2 "
+            + PREFIX_MESSAGE + "Send follow-up email "
+            + PREFIX_DATETIME + "2020-10-30 15:00 "
+            + PREFIX_DURATION + "30";
+
+    public static final String MESSAGE_SUCCESS = "New meeting added: %1$s";
+    public static final String MESSAGE_DUPLICATE_MEETING = "This meeting already exists in StonksBook.";
+
+    /**
+     * Index of the Person to be associated with this meeting.
+     */
+    private final Index index;
+    private final String message;
+    private final LocalDateTime startDate;
+    private final Duration duration;
+
+    /**
+     * Creates an AddCommand that adds a {@code Meeting}.
+     *
+     * @param index     The index of the Person to associate this Meeting to.
+     * @param message   The message associated with this Meeting.
+     * @param startDate The start date of the Meeting.
+     * @param duration  The duration of the Meeting.
+     */
+    public AddCommand(Index index, String message, LocalDateTime startDate, Duration duration) {
+        requireAllNonNull(index, message, startDate, duration);
+        this.index = index;
+        this.message = message;
+        this.startDate = startDate;
+        this.duration = duration;
+    }
+
+    @Override
+    public CommandResult execute(Model model) throws CommandException {
+        requireNonNull(model);
+
+        List<Person> lastShownList = model.getFilteredPersonList();
+
+        if (index.getZeroBased() >= lastShownList.size()) {
+            throw new CommandException(Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
+        }
+
+        Person personToAssociateWithMeeting = lastShownList.get(index.getZeroBased());
+        Meeting toAdd = new Meeting(personToAssociateWithMeeting, message, startDate, duration);
+
+        if (model.hasMeeting(toAdd)) {
+            throw new CommandException(MESSAGE_DUPLICATE_MEETING);
+        }
+
+        model.addMeeting(toAdd);
+        return new CommandResult(String.format(MESSAGE_SUCCESS, toAdd));
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        // short circuit if same object
+        if (other == this) {
+            return true;
+        }
+
+        // instanceof handles nulls
+        if (!(other instanceof AddCommand)) {
+            return false;
+        }
+
+        // state check
+        AddCommand otherAddCommand = (AddCommand) other;
+        return index.equals(otherAddCommand.index)
+                && message.equals(otherAddCommand.message)
+                && startDate.equals(otherAddCommand.startDate)
+                && duration.equals(otherAddCommand.duration);
+    }
+}

--- a/src/main/java/seedu/address/logic/commands/meeting/DeleteCommand.java
+++ b/src/main/java/seedu/address/logic/commands/meeting/DeleteCommand.java
@@ -1,0 +1,55 @@
+package seedu.address.logic.commands.meeting;
+
+import static java.util.Objects.requireNonNull;
+import static seedu.address.commons.core.Messages.MESSAGE_INVALID_MEETING_DISPLAYED_INDEX;
+
+import java.util.List;
+
+import seedu.address.commons.core.index.Index;
+import seedu.address.logic.commands.Command;
+import seedu.address.logic.commands.CommandResult;
+import seedu.address.logic.commands.exceptions.CommandException;
+import seedu.address.model.Model;
+import seedu.address.model.meeting.Meeting;
+
+/**
+ * Deletes a meeting based on its displayed index in the meeting list.
+ */
+public class DeleteCommand extends Command {
+
+    public static final String COMMAND_WORD = "meeting delete";
+
+    public static final String MESSAGE_USAGE = COMMAND_WORD
+            + ": Deletes the meeting identified by the index number used in the displayed meeting list.\n"
+            + "Parameters: INDEX (must be a positive integer)\n"
+            + "Example: " + COMMAND_WORD + " 1";
+
+    public static final String MESSAGE_DELETE_MEETING_SUCCESS = "Deleted Meeting: %1$s";
+
+    private final Index targetIndex;
+
+    public DeleteCommand(Index targetIndex) {
+        this.targetIndex = targetIndex;
+    }
+
+    @Override
+    public CommandResult execute(Model model) throws CommandException {
+        requireNonNull(model);
+        List<Meeting> meetingList = model.getMeetingList();
+
+        if (targetIndex.getZeroBased() >= meetingList.size()) {
+            throw new CommandException(MESSAGE_INVALID_MEETING_DISPLAYED_INDEX);
+        }
+
+        Meeting meetingToDelete = meetingList.get(targetIndex.getZeroBased());
+        model.deleteMeeting(meetingToDelete);
+        return new CommandResult(String.format(MESSAGE_DELETE_MEETING_SUCCESS, meetingToDelete));
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return other == this // short circuit if same object
+                || (other instanceof DeleteCommand // instanceof handles nulls
+                && targetIndex.equals(((DeleteCommand) other).targetIndex)); // state check
+    }
+}

--- a/src/main/java/seedu/address/logic/commands/meeting/DeleteCommand.java
+++ b/src/main/java/seedu/address/logic/commands/meeting/DeleteCommand.java
@@ -35,7 +35,7 @@ public class DeleteCommand extends Command {
     @Override
     public CommandResult execute(Model model) throws CommandException {
         requireNonNull(model);
-        List<Meeting> meetingList = model.getMeetingList();
+        List<Meeting> meetingList = model.getSortedMeetingList();
 
         if (targetIndex.getZeroBased() >= meetingList.size()) {
             throw new CommandException(MESSAGE_INVALID_MEETING_DISPLAYED_INDEX);

--- a/src/main/java/seedu/address/logic/commands/meeting/ListCommand.java
+++ b/src/main/java/seedu/address/logic/commands/meeting/ListCommand.java
@@ -24,7 +24,7 @@ public class ListCommand extends Command {
     @Override
     public CommandResult execute(Model model) {
         requireNonNull(model);
-        List<Meeting> meetings = model.getMeetingList();
+        List<Meeting> meetings = model.getSortedMeetingList();
 
         String output;
         if (meetings.size() == 0) {

--- a/src/main/java/seedu/address/logic/commands/meeting/ListCommand.java
+++ b/src/main/java/seedu/address/logic/commands/meeting/ListCommand.java
@@ -1,0 +1,46 @@
+package seedu.address.logic.commands.meeting;
+
+import static java.util.Objects.requireNonNull;
+
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+import seedu.address.commons.core.index.Index;
+import seedu.address.logic.commands.Command;
+import seedu.address.logic.commands.CommandResult;
+import seedu.address.model.Model;
+import seedu.address.model.meeting.Meeting;
+
+/**
+ * Lists all meetings in the address book to the user.
+ */
+public class ListCommand extends Command {
+
+    public static final String COMMAND_WORD = "meeting list";
+
+    public static final String MESSAGE_SUCCESS = "Listed all meetings";
+
+    @Override
+    public CommandResult execute(Model model) {
+        requireNonNull(model);
+        List<Meeting> meetings = model.getMeetingList();
+
+        String output;
+        if (meetings.size() == 0) {
+            output = "No meetings found!";
+        } else {
+            output = IntStream
+                    .range(0, meetings.size())
+                    .mapToObj(i -> String.format("%d. %s", Index.fromZeroBased(i).getOneBased(), meetings.get(i)))
+                    .collect(Collectors.joining("\n"));
+        }
+
+        return new CommandResult(output);
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return other instanceof ListCommand; // instanceof handles nulls
+    }
+}

--- a/src/main/java/seedu/address/logic/parser/AddressBookParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddressBookParser.java
@@ -3,6 +3,7 @@ package seedu.address.logic.parser;
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.commons.core.Messages.MESSAGE_UNKNOWN_COMMAND;
 import static seedu.address.commons.enums.GroupEnum.CONTACT;
+import static seedu.address.commons.enums.GroupEnum.MEETING;
 import static seedu.address.commons.enums.GroupEnum.REMINDER;
 import static seedu.address.commons.enums.GroupEnum.TAG;
 
@@ -15,6 +16,7 @@ import seedu.address.logic.commands.HelpCommand;
 import seedu.address.logic.commands.PurgeCommand;
 import seedu.address.logic.parser.contact.ContactCommandsParser;
 import seedu.address.logic.parser.exceptions.ParseException;
+import seedu.address.logic.parser.meeting.MeetingCommandsParser;
 import seedu.address.logic.parser.reminder.ReminderCommandsParser;
 import seedu.address.logic.parser.tag.TagCommandsParser;
 
@@ -94,8 +96,9 @@ public class AddressBookParser {
         boolean isContactCommand = commandWord.equals(CONTACT.name().toLowerCase());
         boolean isTagCommand = commandWord.equals(TAG.name().toLowerCase());
         boolean isReminderCommand = commandWord.equals(REMINDER.name().toLowerCase());
+        boolean isMeetingCommand = commandWord.equals(MEETING.name().toLowerCase());
 
-        return isContactCommand || isTagCommand || isReminderCommand;
+        return isContactCommand || isTagCommand || isReminderCommand || isMeetingCommand;
     }
 
     private Command parseTwoKeyWordCommand(String commandWord, String secondCommandWord, String arguments)
@@ -109,6 +112,8 @@ public class AddressBookParser {
             return new TagCommandsParser().parse(fullCommand, arguments);
         } else if (commandWord.equals(REMINDER.name().toLowerCase())) {
             return new ReminderCommandsParser().parse(fullCommand, arguments);
+        } else if (commandWord.equals(MEETING.name().toLowerCase())) {
+            return new MeetingCommandsParser().parse(fullCommand, arguments);
         } else {
             throw new ParseException(MESSAGE_UNKNOWN_COMMAND);
         }

--- a/src/main/java/seedu/address/logic/parser/CliSyntax.java
+++ b/src/main/java/seedu/address/logic/parser/CliSyntax.java
@@ -20,4 +20,5 @@ public class CliSyntax {
     public static final Prefix PREFIX_CONTACT = new Prefix("c/");
     public static final Prefix PREFIX_MESSAGE = new Prefix("m/");
     public static final Prefix PREFIX_DATETIME = new Prefix("d/");
+    public static final Prefix PREFIX_DURATION = new Prefix("du/");
 }

--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -118,8 +118,6 @@ public class ParserUtil {
     /**
      * Parses a {@code String remark} into an {@code Remark}.
      * Leading and trailing whitespaces will be trimmed.
-     *
-     * @throws ParseException if the given {@code remark} is invalid.
      */
     public static Remark parseRemark(String remark) {
         requireNonNull(remark);

--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -2,7 +2,9 @@ package seedu.address.logic.parser;
 
 import static java.util.Objects.requireNonNull;
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_DATETIME;
+import static seedu.address.commons.core.Messages.MESSAGE_INVALID_DURATION;
 
+import java.time.Duration;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeParseException;
@@ -166,6 +168,27 @@ public class ParserUtil {
             return LocalDateTime.parse(trimmedDateTime, dateTimeFormatter);
         } catch (DateTimeParseException e) {
             throw new ParseException(MESSAGE_INVALID_DATETIME);
+        }
+    }
+
+    /**
+     * Parses a {@code String duration} into a {@code Duration}.
+     *
+     * @throws ParseException if the given {@code duration} is not a positive integer.
+     */
+    public static Duration parseDuration(String duration) throws ParseException {
+        requireNonNull(duration);
+        String trimmedDuration = duration.trim();
+
+        try {
+            long minutes = Long.parseLong(trimmedDuration);
+            if (minutes <= 0) {
+                throw new ParseException(MESSAGE_INVALID_DURATION);
+            }
+
+            return Duration.ofMinutes(minutes);
+        } catch (NumberFormatException e) {
+            throw new ParseException(MESSAGE_INVALID_DURATION);
         }
     }
 

--- a/src/main/java/seedu/address/logic/parser/meeting/AddCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/meeting/AddCommandParser.java
@@ -33,7 +33,7 @@ public class AddCommandParser implements Parser<AddCommand> {
         ArgumentMultimap argMultimap =
                 ArgumentTokenizer.tokenize(args, PREFIX_CONTACT, PREFIX_MESSAGE, PREFIX_DATETIME, PREFIX_DURATION);
 
-        if (!arePrefixesPresent(argMultimap, PREFIX_CONTACT, PREFIX_MESSAGE, PREFIX_DATETIME)
+        if (!arePrefixesPresent(argMultimap, PREFIX_CONTACT, PREFIX_MESSAGE, PREFIX_DATETIME, PREFIX_DURATION)
                 || !argMultimap.getPreamble().isEmpty()) {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT,
                     AddCommand.MESSAGE_USAGE));

--- a/src/main/java/seedu/address/logic/parser/meeting/AddCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/meeting/AddCommandParser.java
@@ -1,0 +1,55 @@
+package seedu.address.logic.parser.meeting;
+
+import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_CONTACT;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_DATETIME;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_DURATION;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_MESSAGE;
+import static seedu.address.logic.parser.ParserUtil.arePrefixesPresent;
+
+import java.time.Duration;
+import java.time.LocalDateTime;
+
+import seedu.address.commons.core.index.Index;
+import seedu.address.logic.commands.meeting.AddCommand;
+import seedu.address.logic.parser.ArgumentMultimap;
+import seedu.address.logic.parser.ArgumentTokenizer;
+import seedu.address.logic.parser.Parser;
+import seedu.address.logic.parser.ParserUtil;
+import seedu.address.logic.parser.exceptions.ParseException;
+
+/**
+ * Parses input arguments and creates a new AddCommand object for Meeting.
+ */
+public class AddCommandParser implements Parser<AddCommand> {
+
+    /**
+     * Parses the given {@code String} of arguments in the context of the AddCommand
+     * and returns an AddCommand object for execution.
+     *
+     * @throws ParseException if the user input does not conform to the expected format.
+     */
+    public AddCommand parse(String args) throws ParseException {
+        ArgumentMultimap argMultimap =
+                ArgumentTokenizer.tokenize(args, PREFIX_CONTACT, PREFIX_MESSAGE, PREFIX_DATETIME, PREFIX_DURATION);
+
+        if (!arePrefixesPresent(argMultimap, PREFIX_CONTACT, PREFIX_MESSAGE, PREFIX_DATETIME)
+                || !argMultimap.getPreamble().isEmpty()) {
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+                    AddCommand.MESSAGE_USAGE));
+        }
+
+        Index index;
+
+        try {
+            index = ParserUtil.parseIndex(argMultimap.getValue(PREFIX_CONTACT).get());
+        } catch (ParseException pe) {
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddCommand.MESSAGE_USAGE), pe);
+        }
+
+        String message = argMultimap.getValue(PREFIX_MESSAGE).get();
+        LocalDateTime startDate = ParserUtil.parseDateTime(argMultimap.getValue(PREFIX_DATETIME).get());
+        Duration duration = ParserUtil.parseDuration(argMultimap.getValue(PREFIX_DURATION).get());
+        return new AddCommand(index, message, startDate, duration);
+    }
+}

--- a/src/main/java/seedu/address/logic/parser/meeting/DeleteCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/meeting/DeleteCommandParser.java
@@ -1,0 +1,31 @@
+package seedu.address.logic.parser.meeting;
+
+import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+
+import seedu.address.commons.core.index.Index;
+import seedu.address.logic.commands.meeting.DeleteCommand;
+import seedu.address.logic.parser.Parser;
+import seedu.address.logic.parser.ParserUtil;
+import seedu.address.logic.parser.exceptions.ParseException;
+
+/**
+ * Parses input arguments and creates a new DeleteCommand object for Meeting.
+ */
+public class DeleteCommandParser implements Parser<DeleteCommand> {
+
+    /**
+     * Parses the given {@code String} of arguments in the context of the DeleteCommand
+     * and returns a DeleteCommand object for execution.
+     *
+     * @throws ParseException if the user input does not conform to the expected format.
+     */
+    public DeleteCommand parse(String args) throws ParseException {
+        try {
+            Index index = ParserUtil.parseIndex(args);
+            return new DeleteCommand(index);
+        } catch (ParseException pe) {
+            throw new ParseException(
+                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteCommand.MESSAGE_USAGE), pe);
+        }
+    }
+}

--- a/src/main/java/seedu/address/logic/parser/meeting/MeetingCommandsParser.java
+++ b/src/main/java/seedu/address/logic/parser/meeting/MeetingCommandsParser.java
@@ -1,0 +1,41 @@
+package seedu.address.logic.parser.meeting;
+
+import static seedu.address.commons.core.Messages.MESSAGE_UNKNOWN_COMMAND;
+
+import seedu.address.logic.commands.Command;
+import seedu.address.logic.commands.meeting.AddCommand;
+import seedu.address.logic.commands.meeting.DeleteCommand;
+import seedu.address.logic.commands.meeting.ListCommand;
+import seedu.address.logic.parser.GroupCommandsParser;
+import seedu.address.logic.parser.exceptions.ParseException;
+
+/**
+ * Parses the command word to create a Meeting Command Object corresponding to the command word.
+ */
+public class MeetingCommandsParser implements GroupCommandsParser {
+
+    /**
+     * Parses the command word and arguments to create the appropriate Command Object for Meeting.
+     *
+     * @param commandWord The command to be executed for Meeting.
+     * @param arguments   The arguments to be executed with the commandWord.
+     * @return Command Object for Meeting.
+     * @throws ParseException If the commandWord given is unknown or if the arguments given are invalid.
+     */
+    @Override
+    public Command parse(String commandWord, String arguments) throws ParseException {
+        switch (commandWord) {
+        case AddCommand.COMMAND_WORD:
+            return new AddCommandParser().parse(arguments);
+
+        case DeleteCommand.COMMAND_WORD:
+            return new DeleteCommandParser().parse(arguments);
+
+        case ListCommand.COMMAND_WORD:
+            return new ListCommand();
+
+        default:
+            throw new ParseException(MESSAGE_UNKNOWN_COMMAND);
+        }
+    }
+}

--- a/src/main/java/seedu/address/model/AddressBook.java
+++ b/src/main/java/seedu/address/model/AddressBook.java
@@ -136,11 +136,12 @@ public class AddressBook implements ReadOnlyAddressBook {
     }
 
     /**
-     * Removes {@code key} from this {@code AddressBook}.
+     * Removes {@code key} from this {@code AddressBook}. All associated meetings will be removed as well.
      * {@code key} must exist in the address book.
      */
     public void removePerson(Person key) {
         persons.remove(key);
+        meetings.removeMeetingsWithContact(key);
     }
 
     //// tag-level operations

--- a/src/main/java/seedu/address/model/Model.java
+++ b/src/main/java/seedu/address/model/Model.java
@@ -155,10 +155,10 @@ public interface Model {
     void updateSortedPersonList(Comparator<Person> comparator);
 
     /**
-     * Returns an unmodifiable view of the meeting list.
+     * Returns an unmodifiable view of the sorted meeting list.
      * .
      */
-    ObservableList<Meeting> getMeetingList();
+    ObservableList<Meeting> getSortedMeetingList();
 
     /**
      * Returns true if an meeting with same fields as {@code meeting} exists in StonksBook.

--- a/src/main/java/seedu/address/model/Model.java
+++ b/src/main/java/seedu/address/model/Model.java
@@ -155,6 +155,12 @@ public interface Model {
     void updateSortedPersonList(Comparator<Person> comparator);
 
     /**
+     * Returns an unmodifiable view of the meeting list.
+     * .
+     */
+    ObservableList<Meeting> getMeetingList();
+
+    /**
      * Returns true if an meeting with same fields as {@code meeting} exists in StonksBook.
      */
     boolean hasMeeting(Meeting meeting);

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -32,6 +32,8 @@ public class ModelManager implements Model {
 
     private final SortedList<Person> sortedPersons;
 
+    private final SortedList<Meeting> sortedMeetings;
+
     /**
      * Initializes a ModelManager with the given addressBook and userPrefs.
      */
@@ -45,6 +47,7 @@ public class ModelManager implements Model {
         this.userPrefs = new UserPrefs(userPrefs);
         this.filteredPersons = new FilteredList<>(this.addressBook.getPersonList());
         this.sortedPersons = new SortedList<>(this.filteredPersons);
+        this.sortedMeetings = new SortedList<>(this.addressBook.getMeetingList(), Comparator.naturalOrder());
     }
 
     public ModelManager() {
@@ -249,8 +252,8 @@ public class ModelManager implements Model {
      * {@code versionedAddressBook}.
      */
     @Override
-    public ObservableList<Meeting> getMeetingList() {
-        return this.addressBook.getMeetingList();
+    public ObservableList<Meeting> getSortedMeetingList() {
+        return this.sortedMeetings;
     }
 
     @Override

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -242,6 +242,16 @@ public class ModelManager implements Model {
         this.sortedPersons.setComparator(comparator);
     }
 
+    //=========== Meeting List Accessors =============================================================
+
+    /**
+     * Returns an unmodifiable view of the list of {@code Meeting} backed by the internal list of
+     * {@code versionedAddressBook}.
+     */
+    @Override
+    public ObservableList<Meeting> getMeetingList() {
+        return this.addressBook.getMeetingList();
+    }
 
     @Override
     public String listTags() {

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -276,9 +276,10 @@ public class ModelManager implements Model {
         // state check
         ModelManager other = (ModelManager) obj;
         return this.addressBook.equals(other.addressBook)
-            && this.userPrefs.equals(other.userPrefs)
-            && this.filteredPersons.equals(other.filteredPersons)
-                && this.sortedPersons.equals(other.sortedPersons);
+                && this.userPrefs.equals(other.userPrefs)
+                && this.filteredPersons.equals(other.filteredPersons)
+                && this.sortedPersons.equals(other.sortedPersons)
+                && this.sortedMeetings.equals(other.sortedMeetings);
     }
 
 }

--- a/src/main/java/seedu/address/model/meeting/Meeting.java
+++ b/src/main/java/seedu/address/model/meeting/Meeting.java
@@ -13,7 +13,7 @@ import seedu.address.model.person.Person;
  * Represents a Meeting that is associated with a Person in the address book.
  * Guarantees: details are present and not null, field values are validated, immutable.
  */
-public class Meeting {
+public class Meeting implements Comparable<Meeting> {
     // For formatting of the scheduled date that is to be printed to the UI.
     private static final DateTimeFormatter DATE_TIME_FORMATTER = DateTimeFormatter.ofPattern("E, dd MMM yyyy, HH:mm");
 
@@ -85,10 +85,10 @@ public class Meeting {
         Meeting otherMeeting = (Meeting) other;
 
         return this.person.equals(otherMeeting.person)
-            // Case-insensitive equality checking
-            && this.message.toLowerCase().equals(otherMeeting.message.toLowerCase())
-            && this.startDate.equals(otherMeeting.startDate)
-            && this.duration.equals(otherMeeting.duration);
+                // Case-insensitive equality checking
+                && this.message.toLowerCase().equals(otherMeeting.message.toLowerCase())
+                && this.startDate.equals(otherMeeting.startDate)
+                && this.duration.equals(otherMeeting.duration);
     }
 
     @Override
@@ -96,4 +96,21 @@ public class Meeting {
         return Objects.hash(this.person, this.message, this.startDate, this.duration);
     }
 
+    /**
+     * Compares this meeting to the specified Meeting. A Meeting is "less" than another Meeting if and only if it
+     * starts earlier than the other Meeting. If both Meetings have the same start date, than the meeting with the
+     * shorter duration will be considered "less".
+     *
+     * @param otherMeeting The other meeting to compare to.
+     * @return The comparator value, negative if less, positive if greater.
+     */
+    @Override
+    public int compareTo(Meeting otherMeeting) {
+        int cmpStartDate = this.startDate.compareTo(otherMeeting.startDate);
+        if (cmpStartDate != 0) {
+            return cmpStartDate;
+        }
+
+        return this.duration.compareTo(otherMeeting.duration);
+    }
 }

--- a/src/main/java/seedu/address/model/meeting/Meeting.java
+++ b/src/main/java/seedu/address/model/meeting/Meeting.java
@@ -4,6 +4,7 @@ import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
 
 import java.time.Duration;
 import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
 import java.util.Objects;
 
 import seedu.address.model.person.Person;
@@ -13,6 +14,8 @@ import seedu.address.model.person.Person;
  * Guarantees: details are present and not null, field values are validated, immutable.
  */
 public class Meeting {
+    // For formatting of the scheduled date that is to be printed to the UI.
+    private static final DateTimeFormatter DATE_TIME_FORMATTER = DateTimeFormatter.ofPattern("E, dd MMM yyyy, HH:mm");
 
     private final Person person;
     private final String message;
@@ -55,14 +58,11 @@ public class Meeting {
     public String toString() {
         final StringBuilder builder = new StringBuilder();
 
-        builder.append("Meeting with: ")
-            .append(getPerson().getName())
-            .append(" Message: ")
-            .append(getMessage())
-            .append(" From ")
-            .append(getStartDate())
-            .append(" to ")
-            .append(getStartDate().plus(getDuration()));
+        builder.append(getMessage())
+                .append(String.format(" - %s ", getPerson().getName()))
+                .append(String.format("(%s - %s)",
+                        getStartDate().format(DATE_TIME_FORMATTER),
+                        getStartDate().plus(getDuration()).format(DATE_TIME_FORMATTER)));
 
         return builder.toString();
     }

--- a/src/main/java/seedu/address/model/meeting/UniqueMeetingList.java
+++ b/src/main/java/seedu/address/model/meeting/UniqueMeetingList.java
@@ -5,11 +5,13 @@ import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
 
 import java.util.Iterator;
 import java.util.List;
+import java.util.stream.Collectors;
 
 import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
 import seedu.address.model.meeting.exceptions.DuplicateMeetingException;
 import seedu.address.model.meeting.exceptions.MeetingNotFoundException;
+import seedu.address.model.person.Person;
 
 /**
  * A list of meetings that enforces uniqueness between its elements and does not allow nulls.
@@ -50,6 +52,22 @@ public class UniqueMeetingList implements Iterable<Meeting> {
         requireNonNull(toRemove);
         if (!internalList.remove(toRemove)) {
             throw new MeetingNotFoundException();
+        }
+    }
+
+    /**
+     * Removes all meetings associated with the given {@code contact} from the list.
+     *
+     * @param contact The contact whose associated meetings are to be removed.
+     */
+    public void removeMeetingsWithContact(Person contact) {
+        requireNonNull(contact);
+        List<Meeting> meetingsToRemove =
+                internalList.stream().filter(meeting -> meeting.getPerson().equals(contact))
+                        .collect(Collectors.toList());
+
+        for (Meeting meeting : meetingsToRemove) {
+            this.remove(meeting);
         }
     }
 

--- a/src/main/java/seedu/address/model/util/SampleDataUtil.java
+++ b/src/main/java/seedu/address/model/util/SampleDataUtil.java
@@ -1,17 +1,23 @@
 package seedu.address.model.util;
 
+import java.time.Duration;
+import java.time.LocalDateTime;
 import java.util.Arrays;
 import java.util.Set;
 import java.util.stream.Collectors;
 
 import seedu.address.model.AddressBook;
 import seedu.address.model.ReadOnlyAddressBook;
+import seedu.address.model.meeting.Meeting;
+import seedu.address.model.meeting.UniqueMeetingList;
 import seedu.address.model.person.Address;
 import seedu.address.model.person.Email;
 import seedu.address.model.person.Name;
 import seedu.address.model.person.Person;
 import seedu.address.model.person.Phone;
 import seedu.address.model.person.Remark;
+import seedu.address.model.reminder.Reminder;
+import seedu.address.model.reminder.UniqueReminderList;
 import seedu.address.model.tag.Tag;
 
 /**
@@ -20,25 +26,53 @@ import seedu.address.model.tag.Tag;
 public class SampleDataUtil {
     public static Person[] getSamplePersons() {
         return new Person[] {
-            new Person(new Name("Alex Yeoh"), new Phone("87438807"), new Email("alexyeoh@example.com"),
-                new Address("Blk 30 Geylang Street 29, #06-40"),
-                getTagSet("friends"), new Remark("")),
-            new Person(new Name("Bernice Yu"), new Phone("99272758"), new Email("berniceyu@example.com"),
-                new Address("Blk 30 Lorong 3 Serangoon Gardens, #07-18"),
-                getTagSet("colleagues", "friends"), new Remark("")),
-            new Person(new Name("Charlotte Oliveiro"), new Phone("93210283"), new Email("charlotte@example.com"),
-                new Address("Blk 11 Ang Mo Kio Street 74, #11-04"),
-                getTagSet("neighbours"), new Remark("")),
-            new Person(new Name("David Li"), new Phone("91031282"), new Email("lidavid@example.com"),
-                new Address("Blk 436 Serangoon Gardens Street 26, #16-43"),
-                getTagSet("family"), new Remark("")),
-            new Person(new Name("Irfan Ibrahim"), new Phone("92492021"), new Email("irfan@example.com"),
-                new Address("Blk 47 Tampines Street 20, #17-35"),
-                getTagSet("classmates"), new Remark("")),
-            new Person(new Name("Roy Balakrishnan"), new Phone("92624417"), new Email("royb@example.com"),
-                new Address("Blk 45 Aljunied Street 85, #11-31"),
-                getTagSet("colleagues"), new Remark(""))
+                new Person(new Name("Alex Yeoh"), new Phone("87438807"), new Email("alexyeoh@example.com"),
+                        new Address("Blk 30 Geylang Street 29, #06-40"),
+                        getTagSet("friends"), new Remark("")),
+                new Person(new Name("Bernice Yu"), new Phone("99272758"), new Email("berniceyu@example.com"),
+                        new Address("Blk 30 Lorong 3 Serangoon Gardens, #07-18"),
+                        getTagSet("colleagues", "friends"), new Remark("")),
+                new Person(new Name("Charlotte Oliveiro"), new Phone("93210283"), new Email("charlotte@example.com"),
+                        new Address("Blk 11 Ang Mo Kio Street 74, #11-04"),
+                        getTagSet("neighbours"), new Remark("")),
+                new Person(new Name("David Li"), new Phone("91031282"), new Email("lidavid@example.com"),
+                        new Address("Blk 436 Serangoon Gardens Street 26, #16-43"),
+                        getTagSet("family"), new Remark("")),
+                new Person(new Name("Irfan Ibrahim"), new Phone("92492021"), new Email("irfan@example.com"),
+                        new Address("Blk 47 Tampines Street 20, #17-35"),
+                        getTagSet("classmates"), new Remark("")),
+                new Person(new Name("Roy Balakrishnan"), new Phone("92624417"), new Email("royb@example.com"),
+                        new Address("Blk 45 Aljunied Street 85, #11-31"),
+                        getTagSet("colleagues"), new Remark(""))
         };
+    }
+
+    public static UniqueReminderList getSampleReminderList() {
+        Person[] samplePersons = getSamplePersons();
+        Person alex = samplePersons[0];
+        Person charlotte = samplePersons[2];
+
+        UniqueReminderList reminders = new UniqueReminderList();
+        reminders.add(new Reminder(alex, "Send follow up email",
+                LocalDateTime.of(2020, 11, 30, 15, 30)));
+        reminders.add(new Reminder(charlotte, "Draft up sales proposal for upcoming meeting",
+                LocalDateTime.of(2020, 12, 15, 9, 0)));
+
+        return reminders;
+    }
+
+    public static UniqueMeetingList getSampleMeetingList() {
+        Person[] samplePersons = getSamplePersons();
+        Person bernice = samplePersons[1];
+        Person charlotte = samplePersons[2];
+
+        UniqueMeetingList meetings = new UniqueMeetingList();
+        meetings.add(new Meeting(bernice, "Sales Call",
+                LocalDateTime.of(2020, 11, 20, 15, 30), Duration.ofMinutes(30)));
+        meetings.add(new Meeting(charlotte, "Lunch to discuss new recurring purchase requirements",
+                LocalDateTime.of(2020, 12, 20, 12, 0), Duration.ofMinutes(90)));
+
+        return meetings;
     }
 
     public static ReadOnlyAddressBook getSampleAddressBook() {
@@ -46,8 +80,15 @@ public class SampleDataUtil {
         for (Person samplePerson : getSamplePersons()) {
             sampleAb.addPerson(samplePerson);
         }
+        for (Reminder sampleReminder : getSampleReminderList()) {
+            sampleAb.addReminder(sampleReminder);
+        }
+        for (Meeting sampleMeeting : getSampleMeetingList()) {
+            sampleAb.addMeeting(sampleMeeting);
+        }
         return sampleAb;
     }
+
 
     /**
      * Returns a tag set containing the list of strings given.

--- a/src/main/java/seedu/address/model/util/SampleDataUtil.java
+++ b/src/main/java/seedu/address/model/util/SampleDataUtil.java
@@ -26,24 +26,24 @@ import seedu.address.model.tag.Tag;
 public class SampleDataUtil {
     public static Person[] getSamplePersons() {
         return new Person[] {
-                new Person(new Name("Alex Yeoh"), new Phone("87438807"), new Email("alexyeoh@example.com"),
-                        new Address("Blk 30 Geylang Street 29, #06-40"),
-                        getTagSet("friends"), new Remark("")),
-                new Person(new Name("Bernice Yu"), new Phone("99272758"), new Email("berniceyu@example.com"),
-                        new Address("Blk 30 Lorong 3 Serangoon Gardens, #07-18"),
-                        getTagSet("colleagues", "friends"), new Remark("")),
-                new Person(new Name("Charlotte Oliveiro"), new Phone("93210283"), new Email("charlotte@example.com"),
-                        new Address("Blk 11 Ang Mo Kio Street 74, #11-04"),
-                        getTagSet("neighbours"), new Remark("")),
-                new Person(new Name("David Li"), new Phone("91031282"), new Email("lidavid@example.com"),
-                        new Address("Blk 436 Serangoon Gardens Street 26, #16-43"),
-                        getTagSet("family"), new Remark("")),
-                new Person(new Name("Irfan Ibrahim"), new Phone("92492021"), new Email("irfan@example.com"),
-                        new Address("Blk 47 Tampines Street 20, #17-35"),
-                        getTagSet("classmates"), new Remark("")),
-                new Person(new Name("Roy Balakrishnan"), new Phone("92624417"), new Email("royb@example.com"),
-                        new Address("Blk 45 Aljunied Street 85, #11-31"),
-                        getTagSet("colleagues"), new Remark(""))
+            new Person(new Name("Alex Yeoh"), new Phone("87438807"), new Email("alexyeoh@example.com"),
+                    new Address("Blk 30 Geylang Street 29, #06-40"),
+                    getTagSet("friends"), new Remark("")),
+            new Person(new Name("Bernice Yu"), new Phone("99272758"), new Email("berniceyu@example.com"),
+                    new Address("Blk 30 Lorong 3 Serangoon Gardens, #07-18"),
+                    getTagSet("colleagues", "friends"), new Remark("")),
+            new Person(new Name("Charlotte Oliveiro"), new Phone("93210283"), new Email("charlotte@example.com"),
+                    new Address("Blk 11 Ang Mo Kio Street 74, #11-04"),
+                    getTagSet("neighbours"), new Remark("")),
+            new Person(new Name("David Li"), new Phone("91031282"), new Email("lidavid@example.com"),
+                    new Address("Blk 436 Serangoon Gardens Street 26, #16-43"),
+                    getTagSet("family"), new Remark("")),
+            new Person(new Name("Irfan Ibrahim"), new Phone("92492021"), new Email("irfan@example.com"),
+                    new Address("Blk 47 Tampines Street 20, #17-35"),
+                    getTagSet("classmates"), new Remark("")),
+            new Person(new Name("Roy Balakrishnan"), new Phone("92624417"), new Email("royb@example.com"),
+                    new Address("Blk 45 Aljunied Street 85, #11-31"),
+                    getTagSet("colleagues"), new Remark(""))
         };
     }
 

--- a/src/main/resources/text/helpForAllCommands.txt
+++ b/src/main/resources/text/helpForAllCommands.txt
@@ -24,7 +24,7 @@ sale delete	               Deleting a sales item                                
 Meeting commands
 ----------------------
 meeting add	           Adds a meeting with the specified contact               meeting add CONTACT_INDEX m/MESSAGE d/START_DATETIME du/DURATION
-meeting list           Lists all meetings.                                     meetings list [CONTACT_INDEX] [a/]
+meeting list           Lists all meetings.                                     meeting list [CONTACT_INDEX] [a/]
 meeting delete         Deletes the specified meeting                           meeting delete INDEX
 
 

--- a/src/main/resources/text/helpForAllCommands.txt
+++ b/src/main/resources/text/helpForAllCommands.txt
@@ -23,7 +23,7 @@ sale delete	               Deleting a sales item                                
 
 Meeting commands
 ----------------------
-meeting add	           Adds a meeting with the specified contact               meeting add CONTACT_INDEX t/TITLE s/START_DATETIME d/DURATION
+meeting add	           Adds a meeting with the specified contact               meeting add CONTACT_INDEX m/MESSAGE d/START_DATETIME du/DURATION
 meeting list           Lists all meetings.                                     meetings list [CONTACT_INDEX] [a/]
 meeting delete         Deletes the specified meeting                           meeting delete INDEX
 

--- a/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
+++ b/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
@@ -10,6 +10,7 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_CONTACT_PHONE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_CONTACT_REMARK;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_CONTACT_TAG;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_DATETIME;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_DURATION;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_MESSAGE;
 import static seedu.address.testutil.Assert.assertThrows;
 import static seedu.address.testutil.TypicalIndexes.INDEX_SECOND_ITEM;
@@ -46,6 +47,7 @@ public class CommandTestUtil {
     public static final String VALID_DATE_1 = "2020-10-30 15:19";
     public static final String VALID_REMARK_AMY = "";
     public static final String VALID_REMARK_BOB = "Likes cats";
+    public static final String VALID_DURATION_ONE_HOUR = "60";
 
     public static final String NAME_DESC_AMY = " " + PREFIX_CONTACT_NAME + VALID_NAME_AMY;
     public static final String NAME_DESC_BOB = " " + PREFIX_CONTACT_NAME + VALID_NAME_BOB;
@@ -62,14 +64,16 @@ public class CommandTestUtil {
     public static final String MESSAGE_CALL_AMY = " " + PREFIX_MESSAGE + VALID_MESSAGE_CALL_AMY;
     public static final String DATE_1 = " " + PREFIX_DATETIME + VALID_DATE_1;
     public static final String CONTACT_INDEX = " " + PREFIX_CONTACT + INDEX_SECOND_ITEM.getOneBased();
+    public static final String DURATION_ONE_HOUR = " " + PREFIX_DURATION + VALID_DURATION_ONE_HOUR;
 
     public static final String INVALID_NAME_DESC = " " + PREFIX_CONTACT_NAME + "James&"; // '&' not allowed in names
     public static final String INVALID_PHONE_DESC = " " + PREFIX_CONTACT_PHONE + "911a"; // 'a' not allowed in phones
     public static final String INVALID_EMAIL_DESC = " " + PREFIX_CONTACT_EMAIL + "bob!yahoo"; // missing '@' symbol
     public static final String INVALID_ADDRESS_DESC = " "
-        + PREFIX_CONTACT_ADDRESS; // empty string not allowed for addresses
+            + PREFIX_CONTACT_ADDRESS; // empty string not allowed for addresses
     public static final String INVALID_TAG_DESC = " " + PREFIX_CONTACT_TAG + "hubby*"; // '*' not allowed in tags
     public static final String INVALID_DATE = " " + PREFIX_DATETIME + "2020/10/30 15:00";
+    public static final String INVALID_DURATION = " " + PREFIX_DURATION + "-30";
 
     public static final String PREAMBLE_WHITESPACE = "\t  \r  \n";
     public static final String PREAMBLE_NON_EMPTY = "NonEmptyPreamble";

--- a/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
+++ b/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
@@ -63,7 +63,7 @@ public class CommandTestUtil {
     public static final String REMARK_DESC_BOB = " " + PREFIX_CONTACT_REMARK + VALID_REMARK_BOB;
     public static final String MESSAGE_CALL_AMY = " " + PREFIX_MESSAGE + VALID_MESSAGE_CALL_AMY;
     public static final String DATE_1 = " " + PREFIX_DATETIME + VALID_DATE_1;
-    public static final String CONTACT_INDEX = " " + PREFIX_CONTACT + INDEX_SECOND_ITEM.getOneBased();
+    public static final String CONTACT_INDEX_SECOND = " " + PREFIX_CONTACT + INDEX_SECOND_ITEM.getOneBased();
     public static final String DURATION_ONE_HOUR = " " + PREFIX_DURATION + VALID_DURATION_ONE_HOUR;
 
     public static final String INVALID_NAME_DESC = " " + PREFIX_CONTACT_NAME + "James&"; // '&' not allowed in names

--- a/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
+++ b/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
@@ -73,6 +73,7 @@ public class CommandTestUtil {
             + PREFIX_CONTACT_ADDRESS; // empty string not allowed for addresses
     public static final String INVALID_TAG_DESC = " " + PREFIX_CONTACT_TAG + "hubby*"; // '*' not allowed in tags
     public static final String INVALID_DATE = " " + PREFIX_DATETIME + "2020/10/30 15:00";
+    public static final String INVALID_CONTACT_INDEX = " " + PREFIX_CONTACT + "-1";
     public static final String INVALID_DURATION = " " + PREFIX_DURATION + "-30";
 
     public static final String PREAMBLE_WHITESPACE = "\t  \r  \n";

--- a/src/test/java/seedu/address/logic/commands/contact/AddCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/contact/AddCommandTest.java
@@ -203,7 +203,7 @@ public class AddCommandTest {
         }
 
         @Override
-        public ObservableList<Meeting> getMeetingList() {
+        public ObservableList<Meeting> getSortedMeetingList() {
             throw new AssertionError("This method should not be called.");
         }
 

--- a/src/test/java/seedu/address/logic/commands/contact/AddCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/contact/AddCommandTest.java
@@ -203,6 +203,11 @@ public class AddCommandTest {
         }
 
         @Override
+        public ObservableList<Meeting> getMeetingList() {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
         public boolean hasMeeting(Meeting meeting) {
             throw new AssertionError("This method should not be called.");
         }

--- a/src/test/java/seedu/address/logic/parser/CommandParserTestUtil.java
+++ b/src/test/java/seedu/address/logic/parser/CommandParserTestUtil.java
@@ -24,6 +24,20 @@ public class CommandParserTestUtil {
     }
 
     /**
+     * Asserts that the parsing of {@code userInput} and {@code arguments} by {@code parser} is successful and the
+     * command created equals to {@code expectedCommand}.
+     */
+    public static void assertParseSuccess(GroupCommandsParser parser, String userInput,
+                                          String arguments, Command expectedCommand) {
+        try {
+            Command command = parser.parse(userInput, arguments);
+            assertEquals(expectedCommand, command);
+        } catch (ParseException pe) {
+            throw new IllegalArgumentException("Invalid userInput.", pe);
+        }
+    }
+
+    /**
      * Asserts that the parsing of {@code userInput} by {@code parser} is unsuccessful and the error message
      * equals to {@code expectedMessage}.
      */

--- a/src/test/java/seedu/address/logic/parser/ParserUtilTest.java
+++ b/src/test/java/seedu/address/logic/parser/ParserUtilTest.java
@@ -6,6 +6,7 @@ import static seedu.address.logic.parser.ParserUtil.MESSAGE_INVALID_INDEX;
 import static seedu.address.testutil.Assert.assertThrows;
 import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_ITEM;
 
+import java.time.Duration;
 import java.time.LocalDateTime;
 import java.util.Arrays;
 import java.util.Collections;
@@ -33,6 +34,11 @@ public class ParserUtilTest {
     private static final String INVALID_DATETIME_4 = "2020-10-30 8:00";
     private static final String INVALID_DATETIME_5 = "2020-10-30 8:61";
     private static final String INVALID_DATETIME_6 = "30/10/2100 08:31";
+    private static final String INVALID_DURATION_1 = "0";
+    private static final String INVALID_DURATION_2 = "-60";
+    private static final String INVALID_DURATION_3 = "2 hours 30 minutes";
+    private static final String INVALID_DURATION_4 = "30.5";
+    private static final String INVALID_DURATION_5 = "0.00";
 
     private static final String VALID_NAME = "Rachel Walker";
     private static final String VALID_PHONE = "123456";
@@ -43,6 +49,9 @@ public class ParserUtilTest {
 
     private static final String VALID_DATETIME = "2020-10-30 15:19";
     private static final LocalDateTime EXPECTED_DATETIME = LocalDateTime.of(2020, 10, 30, 15, 19);
+
+    private static final String VALID_DURATION = "120";
+    private static final Duration EXPECTED_DURATION = Duration.ofMinutes(120);
 
     private static final String WHITESPACE = " \t\r\n";
 
@@ -230,4 +239,28 @@ public class ParserUtilTest {
         assertEquals(EXPECTED_DATETIME, ParserUtil.parseDateTime(dateTimeWithWhitespace));
     }
 
+    @Test
+    public void parseDuration_null_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> ParserUtil.parseDuration(null));
+    }
+
+    @Test
+    public void parseDuration_invalidValue_throwsParseException() {
+        assertThrows(ParseException.class, () -> ParserUtil.parseDuration(INVALID_DURATION_1));
+        assertThrows(ParseException.class, () -> ParserUtil.parseDuration(INVALID_DURATION_2));
+        assertThrows(ParseException.class, () -> ParserUtil.parseDuration(INVALID_DURATION_3));
+        assertThrows(ParseException.class, () -> ParserUtil.parseDuration(INVALID_DURATION_4));
+        assertThrows(ParseException.class, () -> ParserUtil.parseDuration(INVALID_DURATION_5));
+    }
+
+    @Test
+    public void parseDuration_validValueWithoutWhitespace_returnsDuration() throws Exception {
+        assertEquals(EXPECTED_DURATION, ParserUtil.parseDuration(VALID_DURATION));
+    }
+
+    @Test
+    public void parseDuration_validValueWithWhitespace_returnsDuration() throws Exception {
+        String durationWithWhitespace = WHITESPACE + VALID_DURATION + WHITESPACE;
+        assertEquals(EXPECTED_DURATION, ParserUtil.parseDuration(durationWithWhitespace));
+    }
 }

--- a/src/test/java/seedu/address/logic/parser/meeting/AddCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/meeting/AddCommandParserTest.java
@@ -1,0 +1,85 @@
+package seedu.address.logic.parser.meeting;
+
+import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.commons.core.Messages.MESSAGE_INVALID_DATETIME;
+import static seedu.address.commons.core.Messages.MESSAGE_INVALID_DURATION;
+import static seedu.address.logic.commands.CommandTestUtil.CONTACT_INDEX;
+import static seedu.address.logic.commands.CommandTestUtil.DATE_1;
+import static seedu.address.logic.commands.CommandTestUtil.DURATION_ONE_HOUR;
+import static seedu.address.logic.commands.CommandTestUtil.INVALID_DATE;
+import static seedu.address.logic.commands.CommandTestUtil.INVALID_DURATION;
+import static seedu.address.logic.commands.CommandTestUtil.MESSAGE_CALL_AMY;
+import static seedu.address.logic.commands.CommandTestUtil.PREAMBLE_NON_EMPTY;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_DATE_1;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_DURATION_ONE_HOUR;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_MESSAGE_CALL_AMY;
+import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
+import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
+import static seedu.address.testutil.TypicalDates.TYPICAL_DATE_1;
+import static seedu.address.testutil.TypicalDurations.TYPICAL_DURATION_ONE_HOUR;
+import static seedu.address.testutil.TypicalIndexes.INDEX_SECOND_ITEM;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.logic.commands.meeting.AddCommand;
+
+public class AddCommandParserTest {
+    private AddCommandParser parser = new AddCommandParser();
+
+    @Test
+    public void parse_allFieldsSpecified_success() {
+        String userInput = CONTACT_INDEX + MESSAGE_CALL_AMY + DATE_1 + DURATION_ONE_HOUR;
+
+        AddCommand expectedCommand =
+                new AddCommand(INDEX_SECOND_ITEM, VALID_MESSAGE_CALL_AMY, TYPICAL_DATE_1, TYPICAL_DURATION_ONE_HOUR);
+
+        assertParseSuccess(parser, userInput, expectedCommand);
+    }
+
+
+    @Test
+    public void parse_compulsoryFieldMissing_failure() {
+        String expectedMessage = String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddCommand.MESSAGE_USAGE);
+
+        // missing contact prefix
+        assertParseFailure(parser, INDEX_SECOND_ITEM.getOneBased() + MESSAGE_CALL_AMY + DATE_1, expectedMessage);
+
+        // missing message prefix
+        assertParseFailure(parser,
+                CONTACT_INDEX + VALID_MESSAGE_CALL_AMY + DATE_1 + DURATION_ONE_HOUR,
+                expectedMessage);
+
+        // missing date prefix
+        assertParseFailure(parser,
+                CONTACT_INDEX + MESSAGE_CALL_AMY + VALID_DATE_1 + DURATION_ONE_HOUR,
+                expectedMessage);
+
+        // missing duration prefix
+        assertParseFailure(parser,
+                CONTACT_INDEX + MESSAGE_CALL_AMY + DATE_1 + VALID_DURATION_ONE_HOUR,
+                expectedMessage);
+
+        // all prefixes missing
+        assertParseFailure(parser,
+                INDEX_SECOND_ITEM.getOneBased() + VALID_MESSAGE_CALL_AMY + VALID_DATE_1
+                        + VALID_DURATION_ONE_HOUR,
+                expectedMessage);
+    }
+
+    @Test
+    public void parse_invalidValue_failure() {
+        // invalid date
+        assertParseFailure(parser,
+                CONTACT_INDEX + MESSAGE_CALL_AMY + INVALID_DATE + DURATION_ONE_HOUR,
+                MESSAGE_INVALID_DATETIME);
+
+        // invalid duration
+        assertParseFailure(parser,
+                CONTACT_INDEX + MESSAGE_CALL_AMY + DATE_1 + INVALID_DURATION,
+                MESSAGE_INVALID_DURATION);
+
+        // non-empty preamble
+        assertParseFailure(parser, PREAMBLE_NON_EMPTY + CONTACT_INDEX + MESSAGE_CALL_AMY + DATE_1 + DURATION_ONE_HOUR,
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddCommand.MESSAGE_USAGE));
+    }
+}

--- a/src/test/java/seedu/address/logic/parser/meeting/AddCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/meeting/AddCommandParserTest.java
@@ -6,6 +6,7 @@ import static seedu.address.commons.core.Messages.MESSAGE_INVALID_DURATION;
 import static seedu.address.logic.commands.CommandTestUtil.CONTACT_INDEX_SECOND;
 import static seedu.address.logic.commands.CommandTestUtil.DATE_1;
 import static seedu.address.logic.commands.CommandTestUtil.DURATION_ONE_HOUR;
+import static seedu.address.logic.commands.CommandTestUtil.INVALID_CONTACT_INDEX;
 import static seedu.address.logic.commands.CommandTestUtil.INVALID_DATE;
 import static seedu.address.logic.commands.CommandTestUtil.INVALID_DURATION;
 import static seedu.address.logic.commands.CommandTestUtil.MESSAGE_CALL_AMY;
@@ -68,6 +69,11 @@ public class AddCommandParserTest {
 
     @Test
     public void parse_invalidValue_failure() {
+        // invalid index
+        assertParseFailure(parser,
+                INVALID_CONTACT_INDEX + MESSAGE_CALL_AMY + DATE_1 + DURATION_ONE_HOUR,
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddCommand.MESSAGE_USAGE));
+
         // invalid date
         assertParseFailure(parser,
                 CONTACT_INDEX_SECOND + MESSAGE_CALL_AMY + INVALID_DATE + DURATION_ONE_HOUR,

--- a/src/test/java/seedu/address/logic/parser/meeting/AddCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/meeting/AddCommandParserTest.java
@@ -3,7 +3,7 @@ package seedu.address.logic.parser.meeting;
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_DATETIME;
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_DURATION;
-import static seedu.address.logic.commands.CommandTestUtil.CONTACT_INDEX;
+import static seedu.address.logic.commands.CommandTestUtil.CONTACT_INDEX_SECOND;
 import static seedu.address.logic.commands.CommandTestUtil.DATE_1;
 import static seedu.address.logic.commands.CommandTestUtil.DURATION_ONE_HOUR;
 import static seedu.address.logic.commands.CommandTestUtil.INVALID_DATE;
@@ -28,7 +28,7 @@ public class AddCommandParserTest {
 
     @Test
     public void parse_allFieldsSpecified_success() {
-        String userInput = CONTACT_INDEX + MESSAGE_CALL_AMY + DATE_1 + DURATION_ONE_HOUR;
+        String userInput = CONTACT_INDEX_SECOND + MESSAGE_CALL_AMY + DATE_1 + DURATION_ONE_HOUR;
 
         AddCommand expectedCommand =
                 new AddCommand(INDEX_SECOND_ITEM, VALID_MESSAGE_CALL_AMY, TYPICAL_DATE_1, TYPICAL_DURATION_ONE_HOUR);
@@ -46,17 +46,17 @@ public class AddCommandParserTest {
 
         // missing message prefix
         assertParseFailure(parser,
-                CONTACT_INDEX + VALID_MESSAGE_CALL_AMY + DATE_1 + DURATION_ONE_HOUR,
+                CONTACT_INDEX_SECOND + VALID_MESSAGE_CALL_AMY + DATE_1 + DURATION_ONE_HOUR,
                 expectedMessage);
 
         // missing date prefix
         assertParseFailure(parser,
-                CONTACT_INDEX + MESSAGE_CALL_AMY + VALID_DATE_1 + DURATION_ONE_HOUR,
+                CONTACT_INDEX_SECOND + MESSAGE_CALL_AMY + VALID_DATE_1 + DURATION_ONE_HOUR,
                 expectedMessage);
 
         // missing duration prefix
         assertParseFailure(parser,
-                CONTACT_INDEX + MESSAGE_CALL_AMY + DATE_1 + VALID_DURATION_ONE_HOUR,
+                CONTACT_INDEX_SECOND + MESSAGE_CALL_AMY + DATE_1 + VALID_DURATION_ONE_HOUR,
                 expectedMessage);
 
         // all prefixes missing
@@ -70,16 +70,17 @@ public class AddCommandParserTest {
     public void parse_invalidValue_failure() {
         // invalid date
         assertParseFailure(parser,
-                CONTACT_INDEX + MESSAGE_CALL_AMY + INVALID_DATE + DURATION_ONE_HOUR,
+                CONTACT_INDEX_SECOND + MESSAGE_CALL_AMY + INVALID_DATE + DURATION_ONE_HOUR,
                 MESSAGE_INVALID_DATETIME);
 
         // invalid duration
         assertParseFailure(parser,
-                CONTACT_INDEX + MESSAGE_CALL_AMY + DATE_1 + INVALID_DURATION,
+                CONTACT_INDEX_SECOND + MESSAGE_CALL_AMY + DATE_1 + INVALID_DURATION,
                 MESSAGE_INVALID_DURATION);
 
         // non-empty preamble
-        assertParseFailure(parser, PREAMBLE_NON_EMPTY + CONTACT_INDEX + MESSAGE_CALL_AMY + DATE_1 + DURATION_ONE_HOUR,
+        assertParseFailure(parser,
+                PREAMBLE_NON_EMPTY + CONTACT_INDEX_SECOND + MESSAGE_CALL_AMY + DATE_1 + DURATION_ONE_HOUR,
                 String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddCommand.MESSAGE_USAGE));
     }
 }

--- a/src/test/java/seedu/address/logic/parser/meeting/DeleteCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/meeting/DeleteCommandParserTest.java
@@ -1,0 +1,26 @@
+package seedu.address.logic.parser.meeting;
+
+import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
+import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
+import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_ITEM;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.logic.commands.meeting.DeleteCommand;
+
+public class DeleteCommandParserTest {
+
+    private DeleteCommandParser parser = new DeleteCommandParser();
+
+    @Test
+    public void parse_validArgs_returnsDeleteCommand() {
+        assertParseSuccess(parser, "1", new DeleteCommand(INDEX_FIRST_ITEM));
+    }
+
+    @Test
+    public void parse_invalidArgs_throwsParseException() {
+        assertParseFailure(parser, "a", String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteCommand.MESSAGE_USAGE));
+        assertParseFailure(parser, "-1", String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteCommand.MESSAGE_USAGE));
+    }
+}

--- a/src/test/java/seedu/address/logic/parser/meeting/MeetingCommandsParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/meeting/MeetingCommandsParserTest.java
@@ -1,0 +1,26 @@
+package seedu.address.logic.parser.meeting;
+
+import static seedu.address.commons.core.Messages.MESSAGE_UNKNOWN_COMMAND;
+import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
+import static seedu.address.testutil.Assert.assertThrows;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.logic.commands.meeting.ListCommand;
+import seedu.address.logic.parser.exceptions.ParseException;
+
+public class MeetingCommandsParserTest {
+
+    private final MeetingCommandsParser meetingCommandsParser = new MeetingCommandsParser();
+
+    @Test
+    public void parse_listCommand_returnsListCommand() {
+        assertParseSuccess(meetingCommandsParser, "meeting list", null, new ListCommand());
+    }
+
+    @Test
+    public void parse_unknownCommand_throwsParseException() {
+        assertThrows(ParseException.class, MESSAGE_UNKNOWN_COMMAND, () ->
+                meetingCommandsParser.parse("unknownCommand", null));
+    }
+}

--- a/src/test/java/seedu/address/logic/parser/reminder/AddCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/reminder/AddCommandParserTest.java
@@ -2,7 +2,7 @@ package seedu.address.logic.parser.reminder;
 
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_DATETIME;
-import static seedu.address.logic.commands.CommandTestUtil.CONTACT_INDEX;
+import static seedu.address.logic.commands.CommandTestUtil.CONTACT_INDEX_SECOND;
 import static seedu.address.logic.commands.CommandTestUtil.DATE_1;
 import static seedu.address.logic.commands.CommandTestUtil.INVALID_DATE;
 import static seedu.address.logic.commands.CommandTestUtil.MESSAGE_CALL_AMY;
@@ -23,7 +23,7 @@ public class AddCommandParserTest {
 
     @Test
     public void parse_allFieldsSpecified_success() {
-        String userInput = CONTACT_INDEX + MESSAGE_CALL_AMY + DATE_1;
+        String userInput = CONTACT_INDEX_SECOND + MESSAGE_CALL_AMY + DATE_1;
 
         AddCommand expectedCommand = new AddCommand(INDEX_SECOND_ITEM, VALID_MESSAGE_CALL_AMY, TYPICAL_DATE_1);
 
@@ -40,12 +40,12 @@ public class AddCommandParserTest {
 
         // missing message prefix
         assertParseFailure(parser,
-            CONTACT_INDEX + VALID_MESSAGE_CALL_AMY + DATE_1,
-            expectedMessage);
+                CONTACT_INDEX_SECOND + VALID_MESSAGE_CALL_AMY + DATE_1,
+                expectedMessage);
 
         // missing date prefix
-        assertParseFailure(parser, CONTACT_INDEX + MESSAGE_CALL_AMY + VALID_DATE_1,
-            expectedMessage);
+        assertParseFailure(parser, CONTACT_INDEX_SECOND + MESSAGE_CALL_AMY + VALID_DATE_1,
+                expectedMessage);
 
         // all prefixes missing
         assertParseFailure(parser, INDEX_SECOND_ITEM.getOneBased() + VALID_MESSAGE_CALL_AMY + VALID_DATE_1,
@@ -55,12 +55,12 @@ public class AddCommandParserTest {
     @Test
     public void parse_invalidValue_failure() {
         // invalid date
-        assertParseFailure(parser, CONTACT_INDEX + MESSAGE_CALL_AMY + INVALID_DATE,
-            MESSAGE_INVALID_DATETIME);
+        assertParseFailure(parser, CONTACT_INDEX_SECOND + MESSAGE_CALL_AMY + INVALID_DATE,
+                MESSAGE_INVALID_DATETIME);
 
         // non-empty preamble
-        assertParseFailure(parser, PREAMBLE_NON_EMPTY + CONTACT_INDEX + MESSAGE_CALL_AMY + DATE_1,
-            String
-                .format(MESSAGE_INVALID_COMMAND_FORMAT, AddCommand.MESSAGE_USAGE));
+        assertParseFailure(parser, PREAMBLE_NON_EMPTY + CONTACT_INDEX_SECOND + MESSAGE_CALL_AMY + DATE_1,
+                String
+                        .format(MESSAGE_INVALID_COMMAND_FORMAT, AddCommand.MESSAGE_USAGE));
     }
 }

--- a/src/test/java/seedu/address/model/ModelManagerTest.java
+++ b/src/test/java/seedu/address/model/ModelManagerTest.java
@@ -5,6 +5,8 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.address.model.Model.PREDICATE_SHOW_ALL_PERSONS;
 import static seedu.address.testutil.Assert.assertThrows;
+import static seedu.address.testutil.meeting.TypicalMeetings.MEET_ALICE;
+import static seedu.address.testutil.meeting.TypicalMeetings.PRESENT_PROPOSAL_BENSON;
 import static seedu.address.testutil.person.TypicalPersons.ALICE;
 import static seedu.address.testutil.person.TypicalPersons.BENSON;
 import static seedu.address.testutil.person.TypicalPersons.IDA;
@@ -16,7 +18,10 @@ import java.util.Arrays;
 
 import org.junit.jupiter.api.Test;
 
+import javafx.collections.ObservableList;
 import seedu.address.commons.core.GuiSettings;
+import seedu.address.model.meeting.Meeting;
+import seedu.address.model.meeting.exceptions.MeetingNotFoundException;
 import seedu.address.model.person.NameContainsKeywordsPredicate;
 import seedu.address.model.person.exceptions.PersonNotFoundException;
 import seedu.address.testutil.AddressBookBuilder;
@@ -163,6 +168,32 @@ public class ModelManagerTest {
     }
 
     @Test
+    public void hasMeeting_nullMeeting_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> modelManager.hasMeeting(null));
+    }
+
+    @Test
+    public void hasMeeting_meetingNotInAddressBook_returnsFalse() {
+        assertFalse(modelManager.hasMeeting(MEET_ALICE));
+    }
+
+    @Test
+    public void hasMeeting_meetingInAddressBook_returnsTrue() {
+        modelManager.addMeeting(MEET_ALICE);
+        assertTrue(modelManager.hasMeeting(MEET_ALICE));
+    }
+
+    @Test
+    public void deleteMeeting_invalidMeeting_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> modelManager.deleteMeeting(null));
+    }
+
+    @Test
+    public void deleteMeeting_invalidMeeting_throwsMeetingNotFoundException() {
+        assertThrows(MeetingNotFoundException.class, () -> modelManager.deleteMeeting(MEET_ALICE));
+    }
+
+    @Test
     public void hasReminder_nullReminder_throwsNullPointerException() {
         assertThrows(NullPointerException.class, () -> modelManager.hasReminder(null));
     }
@@ -176,5 +207,16 @@ public class ModelManagerTest {
     public void hasReminder_reminderInAddressBook_returnsTrue() {
         modelManager.addReminder(CALL_ALICE);
         assertTrue(modelManager.hasReminder(CALL_ALICE));
+    }
+
+    @Test
+    public void getSortedMeetingList_meetingWithEarlierDateAdded_meetingInSortedOrder() {
+        modelManager.addMeeting(MEET_ALICE);
+        modelManager.addMeeting(PRESENT_PROPOSAL_BENSON);
+
+        ObservableList<Meeting> meetingList = modelManager.getSortedMeetingList();
+
+        assertEquals(meetingList.get(0), PRESENT_PROPOSAL_BENSON);
+        assertEquals(meetingList.get(1), MEET_ALICE);
     }
 }

--- a/src/test/java/seedu/address/model/meeting/UniqueMeetingListTest.java
+++ b/src/test/java/seedu/address/model/meeting/UniqueMeetingListTest.java
@@ -6,7 +6,10 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.address.testutil.Assert.assertThrows;
 import static seedu.address.testutil.meeting.TypicalMeetings.MEET_ALICE;
 import static seedu.address.testutil.meeting.TypicalMeetings.PRESENT_PROPOSAL_BENSON;
+import static seedu.address.testutil.person.TypicalPersons.ALICE;
 
+import java.time.Duration;
+import java.time.LocalDateTime;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -66,9 +69,36 @@ public class UniqueMeetingListTest {
     }
 
     @Test
+    public void removeMeetingsWithContact_nullContact_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> uniqueMeetingList.removeMeetingsWithContact(null));
+    }
+
+    @Test
+    public void removeMeetingsWithContact_noMeetingsWithContact_noChange() {
+        uniqueMeetingList.removeMeetingsWithContact(ALICE);
+        UniqueMeetingList expectedUniqueMeetingList = new UniqueMeetingList();
+        assertEquals(expectedUniqueMeetingList, uniqueMeetingList);
+    }
+
+    @Test
+    public void removeMeetingsWithContact_contactWithMultipleMeetings_associatedMeetingsRemoved() {
+        uniqueMeetingList.add(MEET_ALICE);
+        uniqueMeetingList.add(PRESENT_PROPOSAL_BENSON);
+        uniqueMeetingList.add(new Meeting(ALICE, "Second meeting with Alice",
+                LocalDateTime.of(2021, 10, 30, 10, 19),
+                Duration.ofMinutes(60)));
+
+        uniqueMeetingList.removeMeetingsWithContact(ALICE);
+
+        UniqueMeetingList expectedUniqueMeetingList = new UniqueMeetingList();
+        expectedUniqueMeetingList.add(PRESENT_PROPOSAL_BENSON);
+
+        assertEquals(expectedUniqueMeetingList, uniqueMeetingList);
+    }
+
+    @Test
     public void setMeetings_nullUniqueMeetingList_throwsNullPointerException() {
-        assertThrows(NullPointerException.class, ()
-            -> uniqueMeetingList.setMeetings((UniqueMeetingList) null));
+        assertThrows(NullPointerException.class, () -> uniqueMeetingList.setMeetings((UniqueMeetingList) null));
     }
 
     @Test

--- a/src/test/java/seedu/address/testutil/TypicalDurations.java
+++ b/src/test/java/seedu/address/testutil/TypicalDurations.java
@@ -1,0 +1,9 @@
+package seedu.address.testutil;
+
+import java.time.Duration;
+
+public class TypicalDurations {
+    public static final Duration TYPICAL_DURATION_ONE_HOUR = Duration.ofMinutes(60);
+    public static final Duration TYPICAL_DURATION_HALF_HOUR = Duration.ofMinutes(30);
+    public static final Duration TYPICAL_DURATION_TWO_DAYS = Duration.ofMinutes(2880);
+}


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/24363622/95670217-17bd3d80-0bbb-11eb-9be8-2bd7f203fb6f.png)

Closes #12

Based on PR #76 
- See here for changes made in this PR: https://github.com/sebastiantoh/tp/compare/rename-appointments...sebastiantoh:meeting-command

Changes:
- Update prefixes used in `meeting add` - rename `t/TITLE` to `m/MESSAGE`, `s/START_DATETIME` to `d/START_DATETIME` and `d/DURATION` to `du/DURATION`
- Command parsing of meeting-related commands
- Display meetings in GUI as per above image. Meetings sorted in increasing order based on the date the meeting is scheduled. Duration is used as a tiebreaker
- Deletion of contacts will cascade and result in deletion of associated meetings (#81)
- Update sample data for meetings and reminders

Not yet implemented:
- Filtering of meetings based on `CONTACT_INDEX` and whether to display past meetings (i.e. `meeting list [c/CONTACT_INDEX] [a/]` does not work. Only `meeting list` does)
