### PR TITLE
Contact Sort and default sorted contact list

### DIFF
--- a/src/main/java/seedu/address/logic/commands/contact/DeleteCommand.java
+++ b/src/main/java/seedu/address/logic/commands/contact/DeleteCommand.java
@@ -35,7 +35,7 @@ public class DeleteCommand extends Command {
     @Override
     public CommandResult execute(Model model) throws CommandException {
         requireNonNull(model);
-        List<Person> lastShownList = model.getFilteredPersonList();
+        List<Person> lastShownList = model.getSortedPersonList();
 
         if (targetIndex.getZeroBased() >= lastShownList.size()) {
             throw new CommandException(Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);

--- a/src/main/java/seedu/address/logic/commands/contact/EditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/contact/EditCommand.java
@@ -73,7 +73,7 @@ public class EditCommand extends Command {
     @Override
     public CommandResult execute(Model model) throws CommandException {
         requireNonNull(model);
-        List<Person> lastShownList = model.getFilteredPersonList();
+        List<Person> lastShownList = model.getSortedPersonList();
 
         if (index.getZeroBased() >= lastShownList.size()) {
             throw new CommandException(Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);

--- a/src/main/java/seedu/address/logic/commands/contact/SortCommand.java
+++ b/src/main/java/seedu/address/logic/commands/contact/SortCommand.java
@@ -4,6 +4,7 @@ import static java.util.Objects.requireNonNull;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_CONTACT_EMAIL;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_CONTACT_NAME;
 
+import java.util.Comparator;
 import java.util.function.Function;
 
 import seedu.address.logic.commands.Command;
@@ -36,6 +37,11 @@ public class SortCommand extends Command {
     private final boolean isDesc;
 
     private Function<Person, String> getSortingValue;
+
+    private final Comparator<Person> nonDescendingComparator = (person1, person2) ->
+            this.getSortingValue.apply(person1).compareToIgnoreCase(this.getSortingValue.apply(person2));
+
+    private final Comparator<Person> nonAscendingComparator = nonDescendingComparator.reversed();
 
     /**
      * Creates a SortCommand to sort the contacts by {@code sortingAttribute}
@@ -73,12 +79,19 @@ public class SortCommand extends Command {
     }
 
     private void sortByAttribute(Model model) {
+        requireNonNull(this.getSortingValue);
         if (!this.isDesc) {
-            model.updateSortedPersonList((person1, person2) -> this.getSortingValue.apply(person1)
-                    .compareToIgnoreCase(this.getSortingValue.apply(person2)));
+            model.updateSortedPersonList(this.nonDescendingComparator);
         } else {
-            model.updateSortedPersonList((person1, person2) -> this.getSortingValue.apply(person2)
-                    .compareToIgnoreCase(this.getSortingValue.apply(person1)));
+            model.updateSortedPersonList(this.nonAscendingComparator);
         }
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return other == this // short circuit if same object
+                || (other instanceof SortCommand // instanceof handles nulls
+                && sortingAttribute.equals(((SortCommand) other).sortingAttribute)
+                && isDesc == ((SortCommand) other).isDesc);
     }
 }

--- a/src/main/java/seedu/address/logic/commands/contact/SortCommand.java
+++ b/src/main/java/seedu/address/logic/commands/contact/SortCommand.java
@@ -61,7 +61,7 @@ public class SortCommand extends Command {
      *
      * @param model {@code Model} which the command should operate on.
      * @return the success message of the SortCommand
-     * @throws CommandException sorting attribute is non existent
+     * @throws CommandException if sorting attribute is non existent
      */
     @Override
     public CommandResult execute(Model model) throws CommandException {

--- a/src/main/java/seedu/address/logic/commands/contact/SortCommand.java
+++ b/src/main/java/seedu/address/logic/commands/contact/SortCommand.java
@@ -1,0 +1,84 @@
+package seedu.address.logic.commands.contact;
+
+import static java.util.Objects.requireNonNull;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_CONTACT_EMAIL;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_CONTACT_NAME;
+
+import java.util.function.Function;
+
+import seedu.address.logic.commands.Command;
+import seedu.address.logic.commands.CommandResult;
+import seedu.address.logic.commands.exceptions.CommandException;
+import seedu.address.logic.parser.Prefix;
+import seedu.address.model.Model;
+import seedu.address.model.person.Person;
+
+/**
+ * sorts the contacts by a particular contact attribute
+ * in non-ascending or non-descending order
+ */
+public class SortCommand extends Command {
+
+    public static final String COMMAND_WORD = "contact sort";
+
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Sorts the contacts."
+            + "Reverts to default sorting when other actions are taken."
+            + "Parameters: KEYWORD [ORDER]\n"
+            + "Example: contact sort n/ desc";
+
+    public static final String MESSAGE_SUCCESS = "sorted!";
+
+    public static final String MESSAGE_SORTING_ATTRIBUTE_NONEXISTENT =
+            "The given attribute to sort by is not valid";
+
+    private final Prefix sortingAttribute;
+
+    private final boolean isDesc;
+
+    private Function<Person, String> getSortingValue;
+
+    /**
+     * Creates a SortCommand to sort the contacts by {@code sortingAttribute}
+     * and the sort order determined by {@code isDesc}.
+     *
+     */
+    public SortCommand(Prefix sortingAttribute, boolean isDesc) {
+        requireNonNull(sortingAttribute);
+        this.sortingAttribute = sortingAttribute;
+        this.isDesc = isDesc;
+    }
+
+    /**
+     * Sorts the contacts based on the given attribute,
+     * in non-ascending order if isDesc is true,
+     * in non-descending order otherwise.
+     *
+     * @param model {@code Model} which the command should operate on.
+     * @return the success message of the SortCommand
+     * @throws CommandException sorting attribute is non existent
+     */
+    @Override
+    public CommandResult execute(Model model) throws CommandException {
+        if (sortingAttribute.equals(PREFIX_CONTACT_NAME)) {
+            this.getSortingValue = person -> person.getName().fullName;
+        } else if (sortingAttribute.equals(PREFIX_CONTACT_EMAIL)) {
+            this.getSortingValue = person -> person.getEmail().value;
+        } else {
+            throw new CommandException(MESSAGE_SORTING_ATTRIBUTE_NONEXISTENT);
+        }
+
+        this.sortByAttribute(model);
+
+        return new CommandResult(MESSAGE_SUCCESS);
+    }
+
+    private void sortByAttribute(Model model) {
+        if (!this.isDesc) {
+            model.updateSortedPersonList((person1, person2) -> this.getSortingValue.apply(person1)
+                    .compareToIgnoreCase(this.getSortingValue.apply(person2)));
+        } else {
+            model.updateSortedPersonList((person1, person2) -> this.getSortingValue.apply(person2)
+                    .compareToIgnoreCase(this.getSortingValue.apply(person1)));
+        }
+    }
+}

--- a/src/main/java/seedu/address/logic/parser/contact/ContactCommandsParser.java
+++ b/src/main/java/seedu/address/logic/parser/contact/ContactCommandsParser.java
@@ -8,6 +8,7 @@ import seedu.address.logic.commands.contact.DeleteCommand;
 import seedu.address.logic.commands.contact.EditCommand;
 import seedu.address.logic.commands.contact.FindCommand;
 import seedu.address.logic.commands.contact.ListCommand;
+import seedu.address.logic.commands.contact.SortCommand;
 import seedu.address.logic.parser.GroupCommandsParser;
 import seedu.address.logic.parser.exceptions.ParseException;
 
@@ -37,6 +38,9 @@ public class ContactCommandsParser implements GroupCommandsParser {
 
         case FindCommand.COMMAND_WORD:
             return new FindCommandParser().parse(arguments);
+
+        case SortCommand.COMMAND_WORD:
+            return new SortCommandParser().parse(arguments);
 
         case ListCommand.COMMAND_WORD:
             return new ListCommand();

--- a/src/main/java/seedu/address/logic/parser/contact/SortCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/contact/SortCommandParser.java
@@ -4,7 +4,6 @@ import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT
 import static seedu.address.logic.parser.CliSyntax.PREFIX_CONTACT_EMAIL;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_CONTACT_NAME;
 
-import seedu.address.logic.commands.contact.AddCommand;
 import seedu.address.logic.commands.contact.SortCommand;
 import seedu.address.logic.parser.ArgumentMultimap;
 import seedu.address.logic.parser.ArgumentTokenizer;
@@ -17,7 +16,7 @@ import seedu.address.logic.parser.exceptions.ParseException;
  */
 public class SortCommandParser implements Parser<SortCommand> {
 
-    private static final String ORDER_KEYWORD = "desc";
+    public static final String ORDER_KEYWORD = "desc";
 
     /**
      * Parses the given {@code String} of arguments in the context of the SortCommand
@@ -46,7 +45,7 @@ public class SortCommandParser implements Parser<SortCommand> {
                 || (!isEmailInputPresent && !isNameInputPresent)
                 || !argMultimap.getPreamble().isEmpty()
                 || (isSecondArgumentPresent && !isSecondArgumentDesc)) {
-            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddCommand.MESSAGE_USAGE));
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, SortCommand.MESSAGE_USAGE));
         }
 
         Prefix sortingAttribute;

--- a/src/main/java/seedu/address/logic/parser/contact/SortCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/contact/SortCommandParser.java
@@ -1,0 +1,62 @@
+package seedu.address.logic.parser.contact;
+
+import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_CONTACT_EMAIL;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_CONTACT_NAME;
+
+import seedu.address.logic.commands.contact.AddCommand;
+import seedu.address.logic.commands.contact.SortCommand;
+import seedu.address.logic.parser.ArgumentMultimap;
+import seedu.address.logic.parser.ArgumentTokenizer;
+import seedu.address.logic.parser.Parser;
+import seedu.address.logic.parser.Prefix;
+import seedu.address.logic.parser.exceptions.ParseException;
+
+/**
+ * Parses input arguments and creates a new SortCommand object for Contact
+ */
+public class SortCommandParser implements Parser<SortCommand> {
+
+    private static final String ORDER_KEYWORD = "desc";
+
+    /**
+     * Parses the given {@code String} of arguments in the context of the SortCommand
+     * and returns a SortCommand object for execution.
+     *
+     * @throws ParseException if the user input does not conform to the expected format
+     */
+    public SortCommand parse(String args) throws ParseException {
+        ArgumentMultimap argMultimap =
+            ArgumentTokenizer.tokenize(args, PREFIX_CONTACT_NAME, PREFIX_CONTACT_EMAIL);
+
+        boolean isNameInputPresent = argMultimap.getValue(PREFIX_CONTACT_NAME).isPresent();
+        boolean isEmailInputPresent = argMultimap.getValue(PREFIX_CONTACT_EMAIL).isPresent();
+
+        String[] argComponents = args.trim().split("\\s+" , 2);
+
+        boolean isSecondArgumentPresent = (argComponents.length == 2);
+
+        boolean isSecondArgumentDesc = false;
+
+        if (isSecondArgumentPresent) {
+            isSecondArgumentDesc = argComponents[1].trim().equals(ORDER_KEYWORD);
+        }
+
+        if ((isEmailInputPresent && isNameInputPresent)
+                || (!isEmailInputPresent && !isNameInputPresent)
+                || !argMultimap.getPreamble().isEmpty()
+                || (isSecondArgumentPresent && !isSecondArgumentDesc)) {
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddCommand.MESSAGE_USAGE));
+        }
+
+        Prefix sortingAttribute;
+
+        if (isNameInputPresent) {
+            sortingAttribute = PREFIX_CONTACT_NAME;
+        } else {
+            sortingAttribute = PREFIX_CONTACT_EMAIL;
+        }
+
+        return new SortCommand(sortingAttribute, isSecondArgumentDesc);
+    }
+}

--- a/src/main/java/seedu/address/model/Model.java
+++ b/src/main/java/seedu/address/model/Model.java
@@ -21,6 +21,13 @@ public interface Model {
     Predicate<Person> PREDICATE_SHOW_ALL_PERSONS = unused -> true;
 
     /**
+     * {@code Comparator} that is used for default sorting of person list in alphabetical order,
+     * ignoring case
+     */
+    Comparator<Person> DEFAULT_PERSON_COMPARATOR = (person1, person2) -> (
+            person1.getName().fullName.compareToIgnoreCase(person2.getName().fullName));
+
+    /**
      * Replaces user prefs data with the data in {@code userPrefs}.
      */
     void setUserPrefs(ReadOnlyUserPrefs userPrefs);

--- a/src/main/java/seedu/address/model/Model.java
+++ b/src/main/java/seedu/address/model/Model.java
@@ -22,7 +22,7 @@ public interface Model {
 
     /**
      * {@code Comparator} that is used for default sorting of person list in alphabetical order,
-     * ignoring case
+     * ignoring case.
      */
     Comparator<Person> DEFAULT_PERSON_COMPARATOR = (person1, person2) -> (
             person1.getName().fullName.compareToIgnoreCase(person2.getName().fullName));

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -45,6 +45,7 @@ public class ModelManager implements Model {
         this.userPrefs = new UserPrefs(userPrefs);
         this.filteredPersons = new FilteredList<>(this.addressBook.getPersonList());
         this.sortedPersons = new SortedList<>(this.filteredPersons);
+        this.updateSortedPersonList(DEFAULT_PERSON_COMPARATOR);
     }
 
     public ModelManager() {
@@ -209,7 +210,7 @@ public class ModelManager implements Model {
 
     /**
      * Updates the predicate used to filter person list and
-     * set comparator for sorted list to be null.
+     * set comparator for sorted person list to be the default comparator.
      *
      * @param predicate predicate to filter person list
      */
@@ -217,9 +218,8 @@ public class ModelManager implements Model {
     public void updateFilteredPersonList(Predicate<Person> predicate) {
         requireNonNull(predicate);
         this.filteredPersons.setPredicate(predicate);
-        this.sortedPersons.setComparator(null);
+        this.sortedPersons.setComparator(DEFAULT_PERSON_COMPARATOR);
     }
-
 
     //=========== Sorted Person List Accessors =============================================================
 

--- a/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
+++ b/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
@@ -137,11 +137,12 @@ public class CommandTestUtil {
         assertEquals(expectedAddressBook, actualModel.getAddressBook());
         assertEquals(expectedFilteredList, actualModel.getFilteredPersonList());
     }
+
     /**
      * Updates {@code model}'s filtered list to show only the person at the given {@code targetIndex} in the
      * {@code model}'s address book.
      */
-    public static void showPersonAtIndex(Model model, Index targetIndex) {
+    public static void showFilteredPersonAtIndex(Model model, Index targetIndex) {
         assertTrue(targetIndex.getZeroBased() < model.getFilteredPersonList().size());
 
         Person person = model.getFilteredPersonList().get(targetIndex.getZeroBased());
@@ -151,4 +152,17 @@ public class CommandTestUtil {
         assertEquals(1, model.getFilteredPersonList().size());
     }
 
+    /**
+     * Updates {@code model}'s sorted list to show only the person at the given {@code targetIndex} in the
+     * {@code model}'s address book.
+     */
+    public static void showSortedPersonAtIndex(Model model, Index targetIndex) {
+        assertTrue(targetIndex.getZeroBased() < model.getSortedPersonList().size());
+
+        Person person = model.getSortedPersonList().get(targetIndex.getZeroBased());
+        final String[] splitName = person.getName().fullName.split("\\s+");
+        model.updateFilteredPersonList(new NameContainsKeywordsPredicate(Arrays.asList(splitName[0])));
+
+        assertEquals(1, model.getFilteredPersonList().size());
+    }
 }

--- a/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
+++ b/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
@@ -152,17 +152,4 @@ public class CommandTestUtil {
         assertEquals(1, model.getFilteredPersonList().size());
     }
 
-    /**
-     * Updates {@code model}'s sorted list to show only the person at the given {@code targetIndex} in the
-     * {@code model}'s address book.
-     */
-    public static void showSortedPersonAtIndex(Model model, Index targetIndex) {
-        assertTrue(targetIndex.getZeroBased() < model.getSortedPersonList().size());
-
-        Person person = model.getSortedPersonList().get(targetIndex.getZeroBased());
-        final String[] splitName = person.getName().fullName.split("\\s+");
-        model.updateFilteredPersonList(new NameContainsKeywordsPredicate(Arrays.asList(splitName[0])));
-
-        assertEquals(1, model.getFilteredPersonList().size());
-    }
 }

--- a/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
+++ b/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
@@ -142,7 +142,7 @@ public class CommandTestUtil {
      * Updates {@code model}'s filtered list to show only the person at the given {@code targetIndex} in the
      * {@code model}'s address book.
      */
-    public static void showFilteredPersonAtIndex(Model model, Index targetIndex) {
+    public static void showPersonAtIndex(Model model, Index targetIndex) {
         assertTrue(targetIndex.getZeroBased() < model.getFilteredPersonList().size());
 
         Person person = model.getFilteredPersonList().get(targetIndex.getZeroBased());

--- a/src/test/java/seedu/address/logic/commands/contact/DeleteCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/contact/DeleteCommandTest.java
@@ -4,8 +4,8 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandFailure;
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
-import static seedu.address.logic.commands.CommandTestUtil.showFilteredPersonAtIndex;
-import static seedu.address.testutil.TypicalAddressBook.getTypicalAddressBook;
+import static seedu.address.logic.commands.CommandTestUtil.showPersonAtIndex;
+import static seedu.address.testutil.TypicalAddressBook.getTypicalAddressBookInReverse;
 import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_ITEM;
 import static seedu.address.testutil.TypicalIndexes.INDEX_SECOND_ITEM;
 
@@ -24,7 +24,7 @@ import seedu.address.model.person.Person;
  */
 public class DeleteCommandTest {
 
-    private Model model = new ModelManager(getTypicalAddressBook(), new UserPrefs());
+    private Model model = new ModelManager(getTypicalAddressBookInReverse(), new UserPrefs());
 
     @Test
     public void execute_validIndexUnfilteredList_success() {
@@ -49,7 +49,7 @@ public class DeleteCommandTest {
 
     @Test
     public void execute_validIndexFilteredList_success() {
-        showFilteredPersonAtIndex(model, INDEX_FIRST_ITEM);
+        showPersonAtIndex(model, INDEX_FIRST_ITEM);
 
         Person personToDelete = model.getSortedPersonList().get(INDEX_FIRST_ITEM.getZeroBased());
         DeleteCommand deleteCommand = new DeleteCommand(INDEX_FIRST_ITEM);
@@ -65,7 +65,7 @@ public class DeleteCommandTest {
 
     @Test
     public void execute_invalidIndexFilteredList_throwsCommandException() {
-        showFilteredPersonAtIndex(model, INDEX_FIRST_ITEM);
+        showPersonAtIndex(model, INDEX_FIRST_ITEM);
 
         Index outOfBoundIndex = INDEX_SECOND_ITEM;
         // ensures that outOfBoundIndex is still in bounds of address book list

--- a/src/test/java/seedu/address/logic/commands/contact/DeleteCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/contact/DeleteCommandTest.java
@@ -4,7 +4,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandFailure;
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
-import static seedu.address.logic.commands.CommandTestUtil.showPersonAtIndex;
+import static seedu.address.logic.commands.CommandTestUtil.showFilteredPersonAtIndex;
 import static seedu.address.testutil.TypicalAddressBook.getTypicalAddressBook;
 import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_ITEM;
 import static seedu.address.testutil.TypicalIndexes.INDEX_SECOND_ITEM;
@@ -28,7 +28,7 @@ public class DeleteCommandTest {
 
     @Test
     public void execute_validIndexUnfilteredList_success() {
-        Person personToDelete = model.getFilteredPersonList().get(INDEX_FIRST_ITEM.getZeroBased());
+        Person personToDelete = model.getSortedPersonList().get(INDEX_FIRST_ITEM.getZeroBased());
         DeleteCommand deleteCommand = new DeleteCommand(INDEX_FIRST_ITEM);
 
         String expectedMessage = String.format(DeleteCommand.MESSAGE_DELETE_PERSON_SUCCESS, personToDelete);
@@ -41,7 +41,7 @@ public class DeleteCommandTest {
 
     @Test
     public void execute_invalidIndexUnfilteredList_throwsCommandException() {
-        Index outOfBoundIndex = Index.fromOneBased(model.getFilteredPersonList().size() + 1);
+        Index outOfBoundIndex = Index.fromOneBased(model.getSortedPersonList().size() + 1);
         DeleteCommand deleteCommand = new DeleteCommand(outOfBoundIndex);
 
         assertCommandFailure(deleteCommand, model, Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
@@ -49,9 +49,9 @@ public class DeleteCommandTest {
 
     @Test
     public void execute_validIndexFilteredList_success() {
-        showPersonAtIndex(model, INDEX_FIRST_ITEM);
+        showFilteredPersonAtIndex(model, INDEX_FIRST_ITEM);
 
-        Person personToDelete = model.getFilteredPersonList().get(INDEX_FIRST_ITEM.getZeroBased());
+        Person personToDelete = model.getSortedPersonList().get(INDEX_FIRST_ITEM.getZeroBased());
         DeleteCommand deleteCommand = new DeleteCommand(INDEX_FIRST_ITEM);
 
         String expectedMessage = String.format(DeleteCommand.MESSAGE_DELETE_PERSON_SUCCESS, personToDelete);
@@ -65,7 +65,7 @@ public class DeleteCommandTest {
 
     @Test
     public void execute_invalidIndexFilteredList_throwsCommandException() {
-        showPersonAtIndex(model, INDEX_FIRST_ITEM);
+        showFilteredPersonAtIndex(model, INDEX_FIRST_ITEM);
 
         Index outOfBoundIndex = INDEX_SECOND_ITEM;
         // ensures that outOfBoundIndex is still in bounds of address book list

--- a/src/test/java/seedu/address/logic/commands/contact/EditCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/contact/EditCommandTest.java
@@ -9,8 +9,8 @@ import static seedu.address.logic.commands.CommandTestUtil.VALID_PHONE_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_TAG_HUSBAND;
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandFailure;
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
-import static seedu.address.logic.commands.CommandTestUtil.showFilteredPersonAtIndex;
-import static seedu.address.testutil.TypicalAddressBook.getTypicalAddressBook;
+import static seedu.address.logic.commands.CommandTestUtil.showPersonAtIndex;
+import static seedu.address.testutil.TypicalAddressBook.getTypicalAddressBookInReverse;
 import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_ITEM;
 import static seedu.address.testutil.TypicalIndexes.INDEX_SECOND_ITEM;
 
@@ -33,7 +33,7 @@ import seedu.address.testutil.person.PersonBuilder;
  */
 public class EditCommandTest {
 
-    private Model model = new ModelManager(getTypicalAddressBook(), new UserPrefs());
+    private Model model = new ModelManager(getTypicalAddressBookInReverse(), new UserPrefs());
 
     @Test
     public void execute_allFieldsSpecifiedUnfilteredList_success() {
@@ -84,7 +84,7 @@ public class EditCommandTest {
 
     @Test
     public void execute_filteredList_success() {
-        showFilteredPersonAtIndex(model, INDEX_FIRST_ITEM);
+        showPersonAtIndex(model, INDEX_FIRST_ITEM);
 
         Person personInFilteredList = model.getSortedPersonList().get(INDEX_FIRST_ITEM.getZeroBased());
         Person editedPerson = new PersonBuilder(personInFilteredList).withName(VALID_NAME_BOB).build();
@@ -110,7 +110,7 @@ public class EditCommandTest {
 
     @Test
     public void execute_duplicatePersonFilteredList_failure() {
-        showFilteredPersonAtIndex(model, INDEX_FIRST_ITEM);
+        showPersonAtIndex(model, INDEX_FIRST_ITEM);
 
         // edit person in filtered list into a duplicate in address book
         Person personInList = model.getAddressBook().getPersonList().get(INDEX_SECOND_ITEM.getZeroBased());
@@ -135,7 +135,7 @@ public class EditCommandTest {
      */
     @Test
     public void execute_invalidPersonIndexFilteredList_failure() {
-        showFilteredPersonAtIndex(model, INDEX_FIRST_ITEM);
+        showPersonAtIndex(model, INDEX_FIRST_ITEM);
         Index outOfBoundIndex = INDEX_SECOND_ITEM;
         // ensures that outOfBoundIndex is still in bounds of address book list
         assertTrue(outOfBoundIndex.getZeroBased() < model.getAddressBook().getPersonList().size());

--- a/src/test/java/seedu/address/logic/commands/contact/EditCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/contact/EditCommandTest.java
@@ -9,7 +9,7 @@ import static seedu.address.logic.commands.CommandTestUtil.VALID_PHONE_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_TAG_HUSBAND;
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandFailure;
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
-import static seedu.address.logic.commands.CommandTestUtil.showPersonAtIndex;
+import static seedu.address.logic.commands.CommandTestUtil.showFilteredPersonAtIndex;
 import static seedu.address.testutil.TypicalAddressBook.getTypicalAddressBook;
 import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_ITEM;
 import static seedu.address.testutil.TypicalIndexes.INDEX_SECOND_ITEM;
@@ -44,15 +44,15 @@ public class EditCommandTest {
         String expectedMessage = String.format(EditCommand.MESSAGE_EDIT_PERSON_SUCCESS, editedPerson);
 
         Model expectedModel = new ModelManager(new AddressBook(model.getAddressBook()), new UserPrefs());
-        expectedModel.setPerson(model.getFilteredPersonList().get(0), editedPerson);
+        expectedModel.setPerson(model.getSortedPersonList().get(0), editedPerson);
 
         assertCommandSuccess(editCommand, model, expectedMessage, expectedModel);
     }
 
     @Test
-    public void execute_someFieldsSpecifiedUnfilteredList_success() {
-        Index indexLastPerson = Index.fromOneBased(model.getFilteredPersonList().size());
-        Person lastPerson = model.getFilteredPersonList().get(indexLastPerson.getZeroBased());
+    public void execute_someFieldsSpecifiedUnfilteredList_failure() {
+        Index indexLastPerson = Index.fromOneBased(model.getSortedPersonList().size());
+        Person lastPerson = model.getSortedPersonList().get(indexLastPerson.getZeroBased());
 
         PersonBuilder personInList = new PersonBuilder(lastPerson);
         Person editedPerson = personInList.withName(VALID_NAME_BOB).withPhone(VALID_PHONE_BOB)
@@ -73,7 +73,7 @@ public class EditCommandTest {
     @Test
     public void execute_noFieldSpecifiedUnfilteredList_success() {
         EditCommand editCommand = new EditCommand(INDEX_FIRST_ITEM, new EditPersonDescriptor());
-        Person editedPerson = model.getFilteredPersonList().get(INDEX_FIRST_ITEM.getZeroBased());
+        Person editedPerson = model.getSortedPersonList().get(INDEX_FIRST_ITEM.getZeroBased());
 
         String expectedMessage = String.format(EditCommand.MESSAGE_EDIT_PERSON_SUCCESS, editedPerson);
 
@@ -84,9 +84,9 @@ public class EditCommandTest {
 
     @Test
     public void execute_filteredList_success() {
-        showPersonAtIndex(model, INDEX_FIRST_ITEM);
+        showFilteredPersonAtIndex(model, INDEX_FIRST_ITEM);
 
-        Person personInFilteredList = model.getFilteredPersonList().get(INDEX_FIRST_ITEM.getZeroBased());
+        Person personInFilteredList = model.getSortedPersonList().get(INDEX_FIRST_ITEM.getZeroBased());
         Person editedPerson = new PersonBuilder(personInFilteredList).withName(VALID_NAME_BOB).build();
         EditCommand editCommand = new EditCommand(INDEX_FIRST_ITEM,
             new EditPersonDescriptorBuilder().withName(VALID_NAME_BOB).build());
@@ -94,14 +94,14 @@ public class EditCommandTest {
         String expectedMessage = String.format(EditCommand.MESSAGE_EDIT_PERSON_SUCCESS, editedPerson);
 
         Model expectedModel = new ModelManager(new AddressBook(model.getAddressBook()), new UserPrefs());
-        expectedModel.setPerson(model.getFilteredPersonList().get(0), editedPerson);
+        expectedModel.setPerson(model.getSortedPersonList().get(0), editedPerson);
 
         assertCommandSuccess(editCommand, model, expectedMessage, expectedModel);
     }
 
     @Test
     public void execute_duplicatePersonUnfilteredList_failure() {
-        Person firstPerson = model.getFilteredPersonList().get(INDEX_FIRST_ITEM.getZeroBased());
+        Person firstPerson = model.getSortedPersonList().get(INDEX_FIRST_ITEM.getZeroBased());
         EditPersonDescriptor descriptor = new EditPersonDescriptorBuilder(firstPerson).build();
         EditCommand editCommand = new EditCommand(INDEX_SECOND_ITEM, descriptor);
 
@@ -110,7 +110,7 @@ public class EditCommandTest {
 
     @Test
     public void execute_duplicatePersonFilteredList_failure() {
-        showPersonAtIndex(model, INDEX_FIRST_ITEM);
+        showFilteredPersonAtIndex(model, INDEX_FIRST_ITEM);
 
         // edit person in filtered list into a duplicate in address book
         Person personInList = model.getAddressBook().getPersonList().get(INDEX_SECOND_ITEM.getZeroBased());
@@ -122,7 +122,7 @@ public class EditCommandTest {
 
     @Test
     public void execute_invalidPersonIndexUnfilteredList_failure() {
-        Index outOfBoundIndex = Index.fromOneBased(model.getFilteredPersonList().size() + 1);
+        Index outOfBoundIndex = Index.fromOneBased(model.getSortedPersonList().size() + 1);
         EditPersonDescriptor descriptor = new EditPersonDescriptorBuilder().withName(VALID_NAME_BOB).build();
         EditCommand editCommand = new EditCommand(outOfBoundIndex, descriptor);
 
@@ -135,7 +135,7 @@ public class EditCommandTest {
      */
     @Test
     public void execute_invalidPersonIndexFilteredList_failure() {
-        showPersonAtIndex(model, INDEX_FIRST_ITEM);
+        showFilteredPersonAtIndex(model, INDEX_FIRST_ITEM);
         Index outOfBoundIndex = INDEX_SECOND_ITEM;
         // ensures that outOfBoundIndex is still in bounds of address book list
         assertTrue(outOfBoundIndex.getZeroBased() < model.getAddressBook().getPersonList().size());

--- a/src/test/java/seedu/address/logic/commands/contact/EditCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/contact/EditCommandTest.java
@@ -50,7 +50,7 @@ public class EditCommandTest {
     }
 
     @Test
-    public void execute_someFieldsSpecifiedUnfilteredList_failure() {
+    public void execute_someFieldsSpecifiedUnfilteredList_success() {
         Index indexLastPerson = Index.fromOneBased(model.getSortedPersonList().size());
         Person lastPerson = model.getSortedPersonList().get(indexLastPerson.getZeroBased());
 

--- a/src/test/java/seedu/address/logic/commands/contact/FindCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/contact/FindCommandTest.java
@@ -5,7 +5,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.address.commons.core.Messages.MESSAGE_PERSONS_LISTED_OVERVIEW;
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
-import static seedu.address.testutil.TypicalAddressBook.getTypicalAddressBook;
+import static seedu.address.testutil.TypicalAddressBook.getTypicalAddressBookInReverse;
 import static seedu.address.testutil.person.TypicalPersons.BENSON;
 import static seedu.address.testutil.person.TypicalPersons.CARL;
 import static seedu.address.testutil.person.TypicalPersons.DANIEL;
@@ -38,8 +38,8 @@ public class FindCommandTest {
 
     @BeforeEach
     void beforeEach() {
-        model = new ModelManager(getTypicalAddressBook(), new UserPrefs());
-        expectedModel = new ModelManager(getTypicalAddressBook(), new UserPrefs());
+        model = new ModelManager(getTypicalAddressBookInReverse(), new UserPrefs());
+        expectedModel = new ModelManager(getTypicalAddressBookInReverse(), new UserPrefs());
         this.model.addPerson(HOON);
         this.model.addPerson(IDA);
 
@@ -91,7 +91,7 @@ public class FindCommandTest {
         FindCommand command = new FindCommand(multipleKeywords);
         expectedModel.updateFilteredPersonList(predicate);
         assertCommandSuccess(command, model, expectedMessage, expectedModel);
-        assertEquals(Arrays.asList(CARL, ELLE, FIONA, IDA), model.getFilteredPersonList());
+        assertEquals(Arrays.asList(CARL, ELLE, FIONA, IDA), model.getSortedPersonList());
     }
 
     @Test
@@ -102,9 +102,8 @@ public class FindCommandTest {
         FindCommand command = new FindCommand(keyword);
         expectedModel.updateFilteredPersonList(predicate);
         assertCommandSuccess(command, model, expectedMessage, expectedModel);
-        assertEquals(Arrays.asList(BENSON, DANIEL, ELLE, HOON, IDA), model.getFilteredPersonList());
+        assertEquals(Arrays.asList(BENSON, DANIEL, ELLE, HOON, IDA), model.getSortedPersonList());
     }
-
 
     @Test
     public void execute_similarMatch_noPersonFound() {
@@ -113,7 +112,7 @@ public class FindCommandTest {
         FindCommand command = new FindCommand(unmatchedKeyword);
         expectedModel.updateFilteredPersonList(x -> false);
         assertCommandSuccess(command, model, expectedMessage, expectedModel);
-        assertEquals(Collections.emptyList(), model.getFilteredPersonList());
+        assertEquals(Collections.emptyList(), model.getSortedPersonList());
     }
 
     @Test
@@ -124,7 +123,7 @@ public class FindCommandTest {
         FindCommand command = new FindCommand(keyword);
         expectedModel.updateFilteredPersonList(predicate);
         assertEquals(new CommandResult(expectedMessage), command.execute(model));
-        assertEquals(Arrays.asList(BENSON, DANIEL, ELLE, HOON, IDA), model.getFilteredPersonList());
+        assertEquals(Arrays.asList(ELLE, DANIEL, BENSON, HOON, IDA), model.getFilteredPersonList());
         assertEquals(Arrays.asList(IDA, BENSON, DANIEL, ELLE, HOON), model.getSortedPersonList());
     }
 }

--- a/src/test/java/seedu/address/logic/commands/contact/ListCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/contact/ListCommandTest.java
@@ -1,7 +1,7 @@
 package seedu.address.logic.commands.contact;
 
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
-import static seedu.address.logic.commands.CommandTestUtil.showPersonAtIndex;
+import static seedu.address.logic.commands.CommandTestUtil.showFilteredPersonAtIndex;
 import static seedu.address.testutil.TypicalAddressBook.getTypicalAddressBook;
 import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_ITEM;
 
@@ -33,7 +33,7 @@ public class ListCommandTest {
 
     @Test
     public void execute_listIsFiltered_showsEverything() {
-        showPersonAtIndex(model, INDEX_FIRST_ITEM);
+        showFilteredPersonAtIndex(model, INDEX_FIRST_ITEM);
         assertCommandSuccess(new ListCommand(), model, ListCommand.MESSAGE_SUCCESS, expectedModel);
     }
 }

--- a/src/test/java/seedu/address/logic/commands/contact/ListCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/contact/ListCommandTest.java
@@ -1,7 +1,7 @@
 package seedu.address.logic.commands.contact;
 
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
-import static seedu.address.logic.commands.CommandTestUtil.showFilteredPersonAtIndex;
+import static seedu.address.logic.commands.CommandTestUtil.showPersonAtIndex;
 import static seedu.address.testutil.TypicalAddressBook.getTypicalAddressBook;
 import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_ITEM;
 
@@ -33,7 +33,7 @@ public class ListCommandTest {
 
     @Test
     public void execute_listIsFiltered_showsEverything() {
-        showFilteredPersonAtIndex(model, INDEX_FIRST_ITEM);
+        showPersonAtIndex(model, INDEX_FIRST_ITEM);
         assertCommandSuccess(new ListCommand(), model, ListCommand.MESSAGE_SUCCESS, expectedModel);
     }
 }

--- a/src/test/java/seedu/address/logic/commands/contact/SortCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/contact/SortCommandTest.java
@@ -1,0 +1,190 @@
+package seedu.address.logic.commands.contact;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.address.logic.commands.CommandTestUtil.assertCommandFailure;
+import static seedu.address.logic.commands.contact.SortCommand.MESSAGE_SORTING_ATTRIBUTE_NONEXISTENT;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_CONTACT_ADDRESS;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_CONTACT_EMAIL;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_CONTACT_NAME;
+import static seedu.address.testutil.TypicalAddressBook.getTypicalAddressBookInReverse;
+import static seedu.address.testutil.sale.TypicalSales.getTypicalAddressBook;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import seedu.address.logic.commands.CommandResult;
+import seedu.address.logic.commands.PurgeCommand;
+import seedu.address.logic.commands.exceptions.CommandException;
+import seedu.address.logic.parser.Prefix;
+import seedu.address.model.AddressBook;
+import seedu.address.model.Model;
+import seedu.address.model.ModelManager;
+import seedu.address.model.UserPrefs;
+
+/**
+ * Contains integration tests (interaction with the Model) and unit tests for SortCommand.
+ */
+public class SortCommandTest {
+
+    private Model model;
+
+    private Model reversedModel;
+
+    @BeforeEach
+    public void init() {
+        model = new ModelManager(getTypicalAddressBook(), new UserPrefs());
+        reversedModel = new ModelManager(getTypicalAddressBookInReverse(), new UserPrefs());
+    }
+
+    @Test
+    public void execute_nameOnly_success() throws CommandException {
+        Prefix prefix = PREFIX_CONTACT_NAME;
+        boolean isDesc = false;
+
+        SortCommand sortCommand = new SortCommand(prefix, isDesc);
+
+        String expectedMessage = SortCommand.MESSAGE_SUCCESS;
+
+        Model expectedModel = new ModelManager(new AddressBook(model.getAddressBook()), new UserPrefs());
+        expectedModel.updateSortedPersonList((x, y) -> x.getName().fullName
+                .compareToIgnoreCase(y.getName().fullName));
+
+        CommandResult commandResult = sortCommand.execute(model);
+
+        assertEquals(new CommandResult(expectedMessage), commandResult);
+        assertEquals(expectedModel, model);
+
+        Model expectedReverseModel = new ModelManager(new AddressBook(reversedModel.getAddressBook()), new UserPrefs());
+        expectedReverseModel.updateSortedPersonList((x, y) -> x.getName().fullName
+                .compareToIgnoreCase(y.getName().fullName));
+
+        commandResult = sortCommand.execute(reversedModel);
+
+        assertEquals(new CommandResult(expectedMessage), commandResult);
+        assertEquals(expectedReverseModel, reversedModel);
+
+    }
+
+    @Test
+    public void execute_nameAndDesc_success() throws CommandException {
+        Prefix prefix = PREFIX_CONTACT_NAME;
+        boolean isDesc = true;
+
+        SortCommand sortCommand = new SortCommand(prefix, isDesc);
+
+        String expectedMessage = SortCommand.MESSAGE_SUCCESS;
+
+        Model expectedModel = new ModelManager(new AddressBook(model.getAddressBook()), new UserPrefs());
+        expectedModel.updateSortedPersonList((x, y) -> y.getName().fullName
+                .compareToIgnoreCase(x.getName().fullName));
+
+        CommandResult commandResult = sortCommand.execute(model);
+
+        assertEquals(new CommandResult(expectedMessage), commandResult);
+        assertEquals(expectedModel, model);
+
+        Model expectedReverseModel = new ModelManager(new AddressBook(reversedModel.getAddressBook()), new UserPrefs());
+        expectedReverseModel.updateSortedPersonList((x, y) -> y.getName().fullName
+                .compareToIgnoreCase(x.getName().fullName));
+
+        commandResult = sortCommand.execute(reversedModel);
+
+        assertEquals(new CommandResult(expectedMessage), commandResult);
+        assertEquals(expectedReverseModel, reversedModel);
+
+    }
+
+    @Test
+    public void execute_emailOnly_success() throws CommandException {
+        Prefix prefix = PREFIX_CONTACT_EMAIL;
+        boolean isDesc = false;
+
+        SortCommand sortCommand = new SortCommand(prefix, isDesc);
+
+        String expectedMessage = SortCommand.MESSAGE_SUCCESS;
+
+        Model expectedModel = new ModelManager(new AddressBook(model.getAddressBook()), new UserPrefs());
+        expectedModel.updateSortedPersonList((x, y) -> x.getEmail().value
+                .compareToIgnoreCase(y.getEmail().value));
+
+        CommandResult commandResult = sortCommand.execute(model);
+
+        assertEquals(new CommandResult(expectedMessage), commandResult);
+        assertEquals(expectedModel, model);
+
+        Model expectedReverseModel = new ModelManager(new AddressBook(reversedModel.getAddressBook()), new UserPrefs());
+        expectedReverseModel.updateSortedPersonList((x, y) -> x.getEmail().value
+                .compareToIgnoreCase(y.getEmail().value));
+
+        commandResult = sortCommand.execute(reversedModel);
+
+        assertEquals(new CommandResult(expectedMessage), commandResult);
+        assertEquals(expectedReverseModel, reversedModel);
+
+    }
+
+    @Test
+    public void execute_emailAndDesc_success() throws CommandException {
+        Prefix prefix = PREFIX_CONTACT_EMAIL;
+        boolean isDesc = true;
+
+        SortCommand sortCommand = new SortCommand(prefix, isDesc);
+
+        String expectedMessage = SortCommand.MESSAGE_SUCCESS;
+
+        Model expectedModel = new ModelManager(new AddressBook(model.getAddressBook()), new UserPrefs());
+        expectedModel.updateSortedPersonList((x, y) -> y.getEmail().value
+                .compareToIgnoreCase(x.getEmail().value));
+
+        CommandResult commandResult = sortCommand.execute(model);
+
+        assertEquals(new CommandResult(expectedMessage), commandResult);
+        assertEquals(expectedModel, model);
+
+        Model expectedReverseModel = new ModelManager(new AddressBook(reversedModel.getAddressBook()), new UserPrefs());
+        expectedReverseModel.updateSortedPersonList((x, y) -> y.getEmail().value
+                .compareToIgnoreCase(x.getEmail().value));
+
+        commandResult = sortCommand.execute(reversedModel);
+
+        assertEquals(new CommandResult(expectedMessage), commandResult);
+        assertEquals(expectedReverseModel, reversedModel);
+
+    }
+
+    @Test
+    public void execute_invalidAttribute_failure() {
+        Prefix prefix = PREFIX_CONTACT_ADDRESS;
+        boolean isDesc = true;
+        SortCommand sortCommand = new SortCommand(prefix, isDesc);
+        String expectedMessage = MESSAGE_SORTING_ATTRIBUTE_NONEXISTENT;
+        assertCommandFailure(sortCommand, model, expectedMessage);
+    }
+
+    @Test
+    public void equals() {
+        final SortCommand standardCommand = new SortCommand(PREFIX_CONTACT_NAME, true);
+
+        // same values -> returns true
+        SortCommand commandWithSameValues = new SortCommand(PREFIX_CONTACT_NAME, true);
+        assertTrue(standardCommand.equals(commandWithSameValues));
+
+        // same object -> returns true
+        assertTrue(standardCommand.equals(standardCommand));
+
+        // null -> returns false
+        assertFalse(standardCommand.equals(null));
+
+        // different types -> returns false
+        assertFalse(standardCommand.equals(new PurgeCommand()));
+
+        // different prefix -> returns false
+        assertFalse(standardCommand.equals(new SortCommand(PREFIX_CONTACT_EMAIL, true)));
+
+        // different isDesc boolean -> returns false
+        assertFalse(standardCommand.equals(new SortCommand(PREFIX_CONTACT_NAME, false)));
+    }
+
+}

--- a/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
@@ -4,6 +4,8 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.commons.core.Messages.MESSAGE_UNKNOWN_COMMAND;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_CONTACT_EMAIL;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_CONTACT_NAME;
 import static seedu.address.testutil.Assert.assertThrows;
 import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_ITEM;
 
@@ -18,6 +20,8 @@ import seedu.address.logic.commands.contact.EditCommand;
 import seedu.address.logic.commands.contact.EditCommand.EditPersonDescriptor;
 import seedu.address.logic.commands.contact.FindCommand;
 import seedu.address.logic.commands.contact.ListCommand;
+import seedu.address.logic.commands.contact.SortCommand;
+import seedu.address.logic.parser.contact.SortCommandParser;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.person.Person;
 import seedu.address.testutil.person.EditPersonDescriptorBuilder;
@@ -81,6 +85,13 @@ public class AddressBookParserTest {
     public void parseCommand_list() throws Exception {
         assertTrue(parser.parseCommand(ListCommand.COMMAND_WORD) instanceof ListCommand);
         assertTrue(parser.parseCommand(ListCommand.COMMAND_WORD + " 3") instanceof ListCommand);
+    }
+
+    @Test
+    public void parseCommand_sort() throws Exception {
+        assertTrue(parser.parseCommand(SortCommand.COMMAND_WORD + " " + PREFIX_CONTACT_NAME) instanceof SortCommand);
+        assertTrue(parser.parseCommand(SortCommand.COMMAND_WORD + " " + PREFIX_CONTACT_EMAIL + " "
+                + SortCommandParser.ORDER_KEYWORD) instanceof SortCommand);
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/parser/contact/SortCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/contact/SortCommandParserTest.java
@@ -1,0 +1,104 @@
+package seedu.address.logic.parser.contact;
+
+import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_CONTACT_ADDRESS;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_CONTACT_EMAIL;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_CONTACT_NAME;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_SALE_QUANTITY;
+import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
+import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
+import static seedu.address.logic.parser.contact.SortCommandParser.ORDER_KEYWORD;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.logic.commands.contact.SortCommand;
+
+public class SortCommandParserTest {
+
+    private final SortCommandParser sortCommandParser = new SortCommandParser();
+
+    @Test
+    public void parse_nameOnly_success() {
+        String args = " " + PREFIX_CONTACT_NAME.getPrefix();
+        SortCommand expectedSortCommand = new SortCommand(PREFIX_CONTACT_NAME, false);
+        assertParseSuccess(sortCommandParser, args, expectedSortCommand);
+    }
+
+    @Test
+    public void parse_emailOnly_success() {
+        String args = " " + PREFIX_CONTACT_EMAIL.getPrefix();
+        SortCommand expectedSortCommand = new SortCommand(PREFIX_CONTACT_EMAIL, false);
+        assertParseSuccess(sortCommandParser, args, expectedSortCommand);
+    }
+
+    @Test
+    public void parse_nameAndDesc_success() {
+        String args = " " + PREFIX_CONTACT_NAME.getPrefix() + " " + ORDER_KEYWORD;
+        SortCommand expectedSortCommand = new SortCommand(PREFIX_CONTACT_NAME, true);
+        assertParseSuccess(sortCommandParser, args, expectedSortCommand);
+    }
+
+    @Test
+    public void parse_emailAndDesc_success() {
+        String args = " " + PREFIX_CONTACT_EMAIL.getPrefix() + " " + ORDER_KEYWORD;
+        SortCommand expectedSortCommand = new SortCommand(PREFIX_CONTACT_EMAIL, true);
+        assertParseSuccess(sortCommandParser, args, expectedSortCommand);
+    }
+
+    @Test
+    public void parse_noInputs_failure() {
+        String args = " ";
+        assertParseFailure(sortCommandParser, args,
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, SortCommand.MESSAGE_USAGE));
+    }
+
+    @Test
+    public void parse_invalidAttribute_failure() {
+        String args = " " + PREFIX_CONTACT_ADDRESS;
+        assertParseFailure(sortCommandParser, args,
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, SortCommand.MESSAGE_USAGE));
+    }
+
+    @Test
+    public void parse_nonExistentAttribute_failure() {
+        String args = " " + PREFIX_SALE_QUANTITY;
+        assertParseFailure(sortCommandParser, args,
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, SortCommand.MESSAGE_USAGE));
+    }
+
+    @Test
+    public void parse_noAttributeAndDesc_failure() {
+        String args = " " + ORDER_KEYWORD;
+        assertParseFailure(sortCommandParser, args,
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, SortCommand.MESSAGE_USAGE));
+    }
+
+    @Test
+    public void parse_twoAttributes_failure() {
+        String args = " " + PREFIX_CONTACT_EMAIL + " " + PREFIX_CONTACT_NAME;
+        assertParseFailure(sortCommandParser, args,
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, SortCommand.MESSAGE_USAGE));
+    }
+
+    @Test
+    public void parse_twoAttributesAndDesc_failure() {
+        String args = " " + PREFIX_CONTACT_EMAIL + " " + PREFIX_CONTACT_NAME
+                + " " + ORDER_KEYWORD;
+        assertParseFailure(sortCommandParser, args,
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, SortCommand.MESSAGE_USAGE));
+    }
+
+    @Test
+    public void parse_validAttributeAndNotDesc_failure() {
+        String args = " " + PREFIX_CONTACT_EMAIL + " " + "lol";
+        assertParseFailure(sortCommandParser, args,
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, SortCommand.MESSAGE_USAGE));
+    }
+
+    @Test
+    public void parse_validAttributeAndDESC_failure() {
+        String args = " " + PREFIX_CONTACT_EMAIL + " " + ORDER_KEYWORD.toUpperCase();
+        assertParseFailure(sortCommandParser, args,
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, SortCommand.MESSAGE_USAGE));
+    }
+}

--- a/src/test/java/seedu/address/logic/parser/contact/SortCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/contact/SortCommandParserTest.java
@@ -96,7 +96,7 @@ public class SortCommandParserTest {
     }
 
     @Test
-    public void parse_validAttributeAndDESC_failure() {
+    public void parse_validAttributeAndDescUpperCase_failure() {
         String args = " " + PREFIX_CONTACT_EMAIL + " " + ORDER_KEYWORD.toUpperCase();
         assertParseFailure(sortCommandParser, args,
                 String.format(MESSAGE_INVALID_COMMAND_FORMAT, SortCommand.MESSAGE_USAGE));

--- a/src/test/java/seedu/address/testutil/TypicalAddressBook.java
+++ b/src/test/java/seedu/address/testutil/TypicalAddressBook.java
@@ -28,7 +28,6 @@ public class TypicalAddressBook {
         return ab;
     }
 
-
     /**
      * Returns an {@code AddressBook} with all the typical entries in reverse order.
      */

--- a/src/test/java/seedu/address/testutil/TypicalAddressBook.java
+++ b/src/test/java/seedu/address/testutil/TypicalAddressBook.java
@@ -2,6 +2,7 @@ package seedu.address.testutil;
 
 import static seedu.address.testutil.appointment.TypicalAppointments.getTypicalAppointments;
 import static seedu.address.testutil.person.TypicalPersons.getTypicalPersons;
+import static seedu.address.testutil.person.TypicalPersons.getTypicalPersonsInReverse;
 import static seedu.address.testutil.reminder.TypicalReminders.getTypicalReminders;
 
 import seedu.address.model.AddressBook;
@@ -16,6 +17,24 @@ public class TypicalAddressBook {
     public static AddressBook getTypicalAddressBook() {
         AddressBook ab = new AddressBook();
         for (Person person : getTypicalPersons()) {
+            ab.addPerson(person);
+        }
+        for (Reminder reminder : getTypicalReminders()) {
+            ab.addReminder(reminder);
+        }
+        for (Appointment appointment : getTypicalAppointments()) {
+            ab.addAppointment(appointment);
+        }
+        return ab;
+    }
+
+
+    /**
+     * Returns an {@code AddressBook} with all the typical entries in reverse order.
+     */
+    public static AddressBook getTypicalAddressBookInReverse() {
+        AddressBook ab = new AddressBook();
+        for (Person person : getTypicalPersonsInReverse()) {
             ab.addPerson(person);
         }
         for (Reminder reminder : getTypicalReminders()) {

--- a/src/test/java/seedu/address/testutil/person/TypicalPersons.java
+++ b/src/test/java/seedu/address/testutil/person/TypicalPersons.java
@@ -15,6 +15,7 @@ import static seedu.address.logic.commands.CommandTestUtil.VALID_TAG_HUSBAND;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 
 import seedu.address.model.person.Person;
@@ -65,5 +66,11 @@ public class TypicalPersons {
 
     public static List<Person> getTypicalPersons() {
         return new ArrayList<>(Arrays.asList(ALICE, BENSON, CARL, DANIEL, ELLE, FIONA, GEORGE));
+    }
+
+    public static List<Person> getTypicalPersonsInReverse() {
+        List<Person> typicalPersons = new ArrayList<>(Arrays.asList(ALICE, BENSON, CARL, DANIEL, ELLE, FIONA, GEORGE));
+        Collections.reverse(typicalPersons);
+        return typicalPersons;
     }
 }


### PR DESCRIPTION
#88  and #86 

**default sorted contact list:**
- sorted in non-descending order by name (ignoring case).
- contact edit, delete changed to make changes on sorted list instead of filtered list.
- after contact edit, contact add, the sorting comparator will be set to default and the full contact list is shown.
- after contact delete, the sorting comparator remains unchanged and the contact list shown at the time will remain unchanged.


**contact sort:**
- able to sort by name or email address **or (total sales (WIP)**
- default sort order for contact sort  is non-descending order.
- if want non-ascending order, add the additional parameter "desc".