### PR TITLE
Fix bug in DeleteCommand for sales

### DIFF
--- a/src/main/java/seedu/address/logic/commands/sale/DeleteCommand.java
+++ b/src/main/java/seedu/address/logic/commands/sale/DeleteCommand.java
@@ -49,7 +49,7 @@ public class DeleteCommand extends Command {
     @Override
     public CommandResult execute(Model model) throws CommandException {
         requireNonNull(model);
-        List<Person> people = model.getAddressBook().getPersonList();
+        List<Person> people = model.getSortedPersonList();
 
         if (contactIndex.getZeroBased() >= people.size()) {
             throw new CommandException(Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);


### PR DESCRIPTION
Use `getSortedPersonList()` in DeleteCommand to get the correct list of contacts displayed to the user 