### PR TITLE
Update GUI to display reminders and meetings as separate components in main window

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -63,10 +63,14 @@ dependencies {
     testImplementation group: 'org.junit.jupiter', name: 'junit-jupiter-api', version: jUnitVersion
 
     testRuntimeOnly group: 'org.junit.jupiter', name: 'junit-jupiter-engine', version: jUnitVersion
+
+    compile 'org.kordamp.ikonli:ikonli-javafx:11.5.0'
+    compile 'org.kordamp.ikonli:ikonli-fontawesome5-pack:11.5.0'
 }
 
 shadowJar {
-    archiveName = 'addressbook.jar'
+    archiveName = 'stonksbook.jar'
+    mergeServiceFiles()
 }
 
 defaultTasks 'clean', 'test'

--- a/docs/index.md
+++ b/docs/index.md
@@ -17,4 +17,4 @@ title: StonksBook
 **Acknowledgements**
 
 * Adapted and evolved from: [AddressBook Level-3](https://se-education.org/addressbook-level3/)
-* Libraries used: [JavaFX](https://openjfx.io/), [Jackson](https://github.com/FasterXML/jackson), [JUnit5](https://github.com/junit-team/junit5), [FontAwesomeFX](https://bitbucket.org/Jerady/fontawesomefx/src/master/)
+* Libraries used: [JavaFX](https://openjfx.io/), [Jackson](https://github.com/FasterXML/jackson), [JUnit5](https://github.com/junit-team/junit5), [Ikonli](https://github.com/kordamp/ikonli)

--- a/docs/index.md
+++ b/docs/index.md
@@ -17,4 +17,4 @@ title: StonksBook
 **Acknowledgements**
 
 * Adapted and evolved from: [AddressBook Level-3](https://se-education.org/addressbook-level3/)
-* Libraries used: [JavaFX](https://openjfx.io/), [Jackson](https://github.com/FasterXML/jackson), [JUnit5](https://github.com/junit-team/junit5)
+* Libraries used: [JavaFX](https://openjfx.io/), [Jackson](https://github.com/FasterXML/jackson), [JUnit5](https://github.com/junit-team/junit5), [FontAwesomeFX](https://bitbucket.org/Jerady/fontawesomefx/src/master/)

--- a/src/main/java/seedu/address/commons/util/DateUtil.java
+++ b/src/main/java/seedu/address/commons/util/DateUtil.java
@@ -1,0 +1,18 @@
+package seedu.address.commons.util;
+
+import java.time.LocalDateTime;
+
+/**
+ * A container for LocalDateTime specific utility functions
+ */
+public class DateUtil {
+    /**
+     * Returns true if {@code date1} and @{code date2} refers to the same day without regards to the time.
+     */
+    public static boolean isSameDay(LocalDateTime date1, LocalDateTime date2) {
+        return LocalDateTime.of(date1.getYear(), date1.getMonthValue(), date1.getDayOfMonth(), 0, 0).equals(
+                LocalDateTime.of(date2.getYear(), date2.getMonthValue(), date2.getDayOfMonth(), 0, 0)
+        );
+    }
+
+}

--- a/src/main/java/seedu/address/logic/Logic.java
+++ b/src/main/java/seedu/address/logic/Logic.java
@@ -10,6 +10,7 @@ import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.ReadOnlyAddressBook;
 import seedu.address.model.meeting.Meeting;
 import seedu.address.model.person.Person;
+import seedu.address.model.reminder.Reminder;
 
 /**
  * API of the Logic component
@@ -32,19 +33,24 @@ public interface Logic {
     ReadOnlyAddressBook getAddressBook();
 
     /**
-     * Returns an unmodifiable view of the filtered list of persons
+     * Returns an unmodifiable view of the filtered list of persons.
      */
     ObservableList<Person> getFilteredPersonList();
 
     /**
-     * Returns an unmodifiable view of the sorted list of persons
+     * Returns an unmodifiable view of the sorted list of persons.
      */
     ObservableList<Person> getSortedPersonList();
 
     /**
-     * Returns an unmodifiable view of the sorted list of meetings
+     * Returns an unmodifiable view of the sorted list of meetings.
      */
     ObservableList<Meeting> getSortedMeetingList();
+
+    /**
+     * Returns an unmodifiable view of the sorted list of reminders.
+     */
+    ObservableList<Reminder> getSortedReminderList();
 
     /**
      * Returns the user prefs' address book file path.

--- a/src/main/java/seedu/address/logic/Logic.java
+++ b/src/main/java/seedu/address/logic/Logic.java
@@ -8,6 +8,7 @@ import seedu.address.logic.commands.CommandResult;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.ReadOnlyAddressBook;
+import seedu.address.model.meeting.Meeting;
 import seedu.address.model.person.Person;
 
 /**
@@ -30,11 +31,20 @@ public interface Logic {
      */
     ReadOnlyAddressBook getAddressBook();
 
-    /** Returns an unmodifiable view of the filtered list of persons */
+    /**
+     * Returns an unmodifiable view of the filtered list of persons
+     */
     ObservableList<Person> getFilteredPersonList();
 
-    /** Returns an unmodifiable view of the sorted list of persons */
+    /**
+     * Returns an unmodifiable view of the sorted list of persons
+     */
     ObservableList<Person> getSortedPersonList();
+
+    /**
+     * Returns an unmodifiable view of the sorted list of meetings
+     */
+    ObservableList<Meeting> getSortedMeetingList();
 
     /**
      * Returns the user prefs' address book file path.

--- a/src/main/java/seedu/address/logic/LogicManager.java
+++ b/src/main/java/seedu/address/logic/LogicManager.java
@@ -14,6 +14,7 @@ import seedu.address.logic.parser.AddressBookParser;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.Model;
 import seedu.address.model.ReadOnlyAddressBook;
+import seedu.address.model.meeting.Meeting;
 import seedu.address.model.person.Person;
 import seedu.address.storage.Storage;
 
@@ -67,6 +68,11 @@ public class LogicManager implements Logic {
     @Override
     public ObservableList<Person> getSortedPersonList() {
         return model.getSortedPersonList();
+    }
+
+    @Override
+    public ObservableList<Meeting> getSortedMeetingList() {
+        return model.getSortedMeetingList();
     }
 
     @Override

--- a/src/main/java/seedu/address/logic/LogicManager.java
+++ b/src/main/java/seedu/address/logic/LogicManager.java
@@ -16,6 +16,7 @@ import seedu.address.model.Model;
 import seedu.address.model.ReadOnlyAddressBook;
 import seedu.address.model.meeting.Meeting;
 import seedu.address.model.person.Person;
+import seedu.address.model.reminder.Reminder;
 import seedu.address.storage.Storage;
 
 /**
@@ -73,6 +74,11 @@ public class LogicManager implements Logic {
     @Override
     public ObservableList<Meeting> getSortedMeetingList() {
         return model.getSortedMeetingList();
+    }
+
+    @Override
+    public ObservableList<Reminder> getSortedReminderList() {
+        return model.getSortedReminderList();
     }
 
     @Override

--- a/src/main/java/seedu/address/logic/commands/meeting/ListCommand.java
+++ b/src/main/java/seedu/address/logic/commands/meeting/ListCommand.java
@@ -2,15 +2,9 @@ package seedu.address.logic.commands.meeting;
 
 import static java.util.Objects.requireNonNull;
 
-import java.util.List;
-import java.util.stream.Collectors;
-import java.util.stream.IntStream;
-
-import seedu.address.commons.core.index.Index;
 import seedu.address.logic.commands.Command;
 import seedu.address.logic.commands.CommandResult;
 import seedu.address.model.Model;
-import seedu.address.model.meeting.Meeting;
 
 /**
  * Lists all meetings in the address book to the user.
@@ -24,19 +18,8 @@ public class ListCommand extends Command {
     @Override
     public CommandResult execute(Model model) {
         requireNonNull(model);
-        List<Meeting> meetings = model.getSortedMeetingList();
 
-        String output;
-        if (meetings.size() == 0) {
-            output = "No meetings found!";
-        } else {
-            output = IntStream
-                    .range(0, meetings.size())
-                    .mapToObj(i -> String.format("%d. %s", Index.fromZeroBased(i).getOneBased(), meetings.get(i)))
-                    .collect(Collectors.joining("\n"));
-        }
-
-        return new CommandResult(output);
+        return new CommandResult(MESSAGE_SUCCESS);
     }
 
     @Override

--- a/src/main/java/seedu/address/model/meeting/Meeting.java
+++ b/src/main/java/seedu/address/model/meeting/Meeting.java
@@ -54,6 +54,14 @@ public class Meeting implements Comparable<Meeting> {
         return this.duration;
     }
 
+    public String getFormattedStartDate() {
+        return getStartDate().format(DATE_TIME_FORMATTER);
+    }
+
+    public String getFormattedEndDate() {
+        return getStartDate().plus(getDuration()).format(DATE_TIME_FORMATTER);
+    }
+
     @Override
     public String toString() {
         final StringBuilder builder = new StringBuilder();
@@ -61,8 +69,8 @@ public class Meeting implements Comparable<Meeting> {
         builder.append(getMessage())
                 .append(String.format(" - %s ", getPerson().getName()))
                 .append(String.format("(%s - %s)",
-                        getStartDate().format(DATE_TIME_FORMATTER),
-                        getStartDate().plus(getDuration()).format(DATE_TIME_FORMATTER)));
+                        getFormattedStartDate(),
+                        getFormattedEndDate()));
 
         return builder.toString();
     }

--- a/src/main/java/seedu/address/model/meeting/Meeting.java
+++ b/src/main/java/seedu/address/model/meeting/Meeting.java
@@ -54,12 +54,11 @@ public class Meeting implements Comparable<Meeting> {
         return this.duration;
     }
 
-    public String getFormattedStartDate() {
-        return getStartDate().format(DATE_TIME_FORMATTER);
-    }
-
-    public String getFormattedEndDate() {
-        return getStartDate().plus(getDuration()).format(DATE_TIME_FORMATTER);
+    public String getFormattedStartEndDate() {
+        return String.format("%s - %s",
+                getStartDate().format(DATE_TIME_FORMATTER),
+                getStartDate().plus(getDuration()).format(DATE_TIME_FORMATTER)
+        );
     }
 
     @Override
@@ -68,9 +67,7 @@ public class Meeting implements Comparable<Meeting> {
 
         builder.append(getMessage())
                 .append(String.format(" - %s ", getPerson().getName()))
-                .append(String.format("(%s - %s)",
-                        getFormattedStartDate(),
-                        getFormattedEndDate()));
+                .append(String.format("(%s)", getFormattedStartEndDate()));
 
         return builder.toString();
     }

--- a/src/main/java/seedu/address/model/meeting/Meeting.java
+++ b/src/main/java/seedu/address/model/meeting/Meeting.java
@@ -1,6 +1,7 @@
 package seedu.address.model.meeting;
 
 import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
+import static seedu.address.commons.util.DateUtil.isSameDay;
 
 import java.time.Duration;
 import java.time.LocalDateTime;
@@ -16,6 +17,10 @@ import seedu.address.model.person.Person;
 public class Meeting implements Comparable<Meeting> {
     // For formatting of the scheduled date that is to be printed to the UI.
     private static final DateTimeFormatter DATE_TIME_FORMATTER = DateTimeFormatter.ofPattern("E, dd MMM yyyy, HH:mm");
+    // For formatting of dates without the time
+    private static final DateTimeFormatter DATE_FORMATTER = DateTimeFormatter.ofPattern("E, dd MMM yyyy");
+    // For formatting of just the hours and minutes
+    private static final DateTimeFormatter TIME_FORMATTER = DateTimeFormatter.ofPattern("HH:mm");
 
     private final Person person;
     private final String message;
@@ -54,11 +59,23 @@ public class Meeting implements Comparable<Meeting> {
         return this.duration;
     }
 
+    /**
+     * Returns a formatted string representation of the meeting's start and end date.
+     * If the meeting starts and ends on the same date, then the format output would be "E, dd MMM yyyy, HH:mm - HH:mm".
+     * Otherwise, the format output is "E, dd MMM yyyy, HH:mm - E, dd MMM yyyy, HH:mm".
+     */
     public String getFormattedStartEndDate() {
-        return String.format("%s - %s",
-                getStartDate().format(DATE_TIME_FORMATTER),
-                getStartDate().plus(getDuration()).format(DATE_TIME_FORMATTER)
-        );
+        LocalDateTime start = getStartDate();
+        LocalDateTime end = getStartDate().plus(getDuration());
+        if (isSameDay(start, end)) {
+            return String.format("%s, %s - %s", start.format(DATE_FORMATTER),
+                    start.format(TIME_FORMATTER), end.format(TIME_FORMATTER));
+        } else {
+            return String.format("%s - %s",
+                    getStartDate().format(DATE_TIME_FORMATTER),
+                    getStartDate().plus(getDuration()).format(DATE_TIME_FORMATTER)
+            );
+        }
     }
 
     @Override

--- a/src/main/java/seedu/address/model/reminder/Reminder.java
+++ b/src/main/java/seedu/address/model/reminder/Reminder.java
@@ -46,6 +46,14 @@ public class Reminder implements Comparable<Reminder> {
         return this.scheduledDate;
     }
 
+    /**
+     * Returns a formatted string representation of the meeting's scheduled date.
+     * Output format is "E, dd MMM yyyy, HH:mm".
+     */
+    public String getFormattedScheduledDate() {
+        return getScheduledDate().format(DATE_TIME_FORMATTER);
+    }
+
     @Override
     public String toString() {
         final StringBuilder builder = new StringBuilder();

--- a/src/main/java/seedu/address/ui/MainWindow.java
+++ b/src/main/java/seedu/address/ui/MainWindow.java
@@ -34,6 +34,7 @@ public class MainWindow extends UiPart<Stage> {
     // Independent Ui parts residing in this Ui container
     private PersonListPanel personListPanel;
     private MeetingListPanel meetingListPanel;
+    private ReminderListPanel reminderListPanel;
     private ChatBox chatBox;
     private HelpWindow helpWindow;
 
@@ -48,6 +49,9 @@ public class MainWindow extends UiPart<Stage> {
 
     @FXML
     private StackPane meetingListPanelPlaceholder;
+
+    @FXML
+    private StackPane reminderListPanelPlaceholder;
 
     @FXML
     private StackPane statusbarPlaceholder;
@@ -122,6 +126,9 @@ public class MainWindow extends UiPart<Stage> {
 
         meetingListPanel = new MeetingListPanel(logic.getSortedMeetingList());
         meetingListPanelPlaceholder.getChildren().add(meetingListPanel.getRoot());
+
+        reminderListPanel = new ReminderListPanel(logic.getSortedReminderList());
+        reminderListPanelPlaceholder.getChildren().add(reminderListPanel.getRoot());
 
         chatBox = new ChatBox();
         chatBoxPlaceholder.getChildren().add(chatBox.getRoot());

--- a/src/main/java/seedu/address/ui/MainWindow.java
+++ b/src/main/java/seedu/address/ui/MainWindow.java
@@ -33,6 +33,7 @@ public class MainWindow extends UiPart<Stage> {
 
     // Independent Ui parts residing in this Ui container
     private PersonListPanel personListPanel;
+    private MeetingListPanel meetingListPanel;
     private ChatBox chatBox;
     private HelpWindow helpWindow;
 
@@ -44,6 +45,9 @@ public class MainWindow extends UiPart<Stage> {
 
     @FXML
     private StackPane personListPanelPlaceholder;
+
+    @FXML
+    private StackPane meetingListPanelPlaceholder;
 
     @FXML
     private StackPane statusbarPlaceholder;
@@ -115,6 +119,9 @@ public class MainWindow extends UiPart<Stage> {
     void fillInnerParts() {
         personListPanel = new PersonListPanel(logic.getSortedPersonList());
         personListPanelPlaceholder.getChildren().add(personListPanel.getRoot());
+
+        meetingListPanel = new MeetingListPanel(logic.getSortedMeetingList());
+        meetingListPanelPlaceholder.getChildren().add(meetingListPanel.getRoot());
 
         chatBox = new ChatBox();
         chatBoxPlaceholder.getChildren().add(chatBox.getRoot());

--- a/src/main/java/seedu/address/ui/MeetingCard.java
+++ b/src/main/java/seedu/address/ui/MeetingCard.java
@@ -22,9 +22,7 @@ public class MeetingCard extends UiPart<Region> {
     @FXML
     private Label message;
     @FXML
-    private Label startDate;
-    @FXML
-    private Label endDate;
+    private Label date;
     @FXML
     private Label personName;
 
@@ -36,8 +34,7 @@ public class MeetingCard extends UiPart<Region> {
         this.meeting = meeting;
         id.setText(displayedIndex + ". ");
         message.setText(meeting.getMessage());
-        startDate.setText(meeting.getFormattedStartDate());
-        endDate.setText(meeting.getFormattedEndDate());
+        date.setText(meeting.getFormattedStartEndDate());
         personName.setText(meeting.getPerson().getName().fullName);
     }
 

--- a/src/main/java/seedu/address/ui/MeetingCard.java
+++ b/src/main/java/seedu/address/ui/MeetingCard.java
@@ -1,0 +1,61 @@
+package seedu.address.ui;
+
+import javafx.fxml.FXML;
+import javafx.scene.control.Label;
+import javafx.scene.layout.HBox;
+import javafx.scene.layout.Region;
+import seedu.address.model.meeting.Meeting;
+
+/**
+ * An UI component that displays information of a {@code Meeting}.
+ */
+public class MeetingCard extends UiPart<Region> {
+
+    private static final String FXML = "MeetingListCard.fxml";
+
+    public final Meeting meeting;
+
+    @FXML
+    private HBox cardPane;
+    @FXML
+    private Label id;
+    @FXML
+    private Label message;
+    @FXML
+    private Label startDate;
+    @FXML
+    private Label endDate;
+    @FXML
+    private Label personName;
+
+    /**
+     * Creates a {@code MeetingCard} with the given {@code Meeting} and index to display.
+     */
+    public MeetingCard(Meeting meeting, int displayedIndex) {
+        super(FXML);
+        this.meeting = meeting;
+        id.setText(displayedIndex + ". ");
+        message.setText(meeting.getMessage());
+        startDate.setText(meeting.getFormattedStartDate());
+        endDate.setText(meeting.getFormattedEndDate());
+        personName.setText(meeting.getPerson().getName().fullName);
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        // short circuit if same object
+        if (other == this) {
+            return true;
+        }
+
+        // instanceof handles nulls
+        if (!(other instanceof MeetingCard)) {
+            return false;
+        }
+
+        // state check
+        MeetingCard card = (MeetingCard) other;
+        return id.getText().equals(card.id.getText())
+                && meeting.equals(card.meeting);
+    }
+}

--- a/src/main/java/seedu/address/ui/MeetingListPanel.java
+++ b/src/main/java/seedu/address/ui/MeetingListPanel.java
@@ -1,0 +1,49 @@
+package seedu.address.ui;
+
+import java.util.logging.Logger;
+
+import javafx.collections.ObservableList;
+import javafx.fxml.FXML;
+import javafx.scene.control.ListCell;
+import javafx.scene.control.ListView;
+import javafx.scene.layout.Region;
+import seedu.address.commons.core.LogsCenter;
+import seedu.address.model.meeting.Meeting;
+
+/**
+ * Panel containing the list of meetings.
+ */
+public class MeetingListPanel extends UiPart<Region> {
+    private static final String FXML = "MeetingListPanel.fxml";
+    private final Logger logger = LogsCenter.getLogger(MeetingListPanel.class);
+
+    @FXML
+    private ListView<Meeting> meetingListView;
+
+    /**
+     * Creates a {@code MeetingListPanel} with the given {@code ObservableList}.
+     */
+    public MeetingListPanel(ObservableList<Meeting> meetingList) {
+        super(FXML);
+        meetingListView.setItems(meetingList);
+        meetingListView.setCellFactory(listView -> new MeetingListViewCell());
+    }
+
+    /**
+     * Custom {@code ListCell} that displays the graphics of a {@code Meeting} using a {@code MeetingCard}.
+     */
+    class MeetingListViewCell extends ListCell<Meeting> {
+        @Override
+        protected void updateItem(Meeting meeting, boolean empty) {
+            super.updateItem(meeting, empty);
+
+            if (empty || meeting == null) {
+                setGraphic(null);
+                setText(null);
+            } else {
+                setGraphic(new MeetingCard(meeting, getIndex() + 1).getRoot());
+            }
+        }
+    }
+
+}

--- a/src/main/java/seedu/address/ui/ReminderCard.java
+++ b/src/main/java/seedu/address/ui/ReminderCard.java
@@ -1,0 +1,58 @@
+package seedu.address.ui;
+
+import javafx.fxml.FXML;
+import javafx.scene.control.Label;
+import javafx.scene.layout.HBox;
+import javafx.scene.layout.Region;
+import seedu.address.model.reminder.Reminder;
+
+/**
+ * An UI component that displays information of a {@code Reminder}.
+ */
+public class ReminderCard extends UiPart<Region> {
+
+    private static final String FXML = "ReminderListCard.fxml";
+
+    public final Reminder reminder;
+
+    @FXML
+    private HBox cardPane;
+    @FXML
+    private Label id;
+    @FXML
+    private Label message;
+    @FXML
+    private Label scheduledDate;
+    @FXML
+    private Label personName;
+
+    /**
+     * Creates a {@code ReminderCard} with the given {@code Reminder} and index to display.
+     */
+    public ReminderCard(Reminder reminder, int displayedIndex) {
+        super(FXML);
+        this.reminder = reminder;
+        id.setText(displayedIndex + ". ");
+        message.setText(reminder.getMessage());
+        scheduledDate.setText(reminder.getFormattedScheduledDate());
+        personName.setText(reminder.getPerson().getName().fullName);
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        // short circuit if same object
+        if (other == this) {
+            return true;
+        }
+
+        // instanceof handles nulls
+        if (!(other instanceof ReminderCard)) {
+            return false;
+        }
+
+        // state check
+        ReminderCard card = (ReminderCard) other;
+        return id.getText().equals(card.id.getText())
+                && reminder.equals(card.reminder);
+    }
+}

--- a/src/main/java/seedu/address/ui/ReminderListPanel.java
+++ b/src/main/java/seedu/address/ui/ReminderListPanel.java
@@ -1,0 +1,49 @@
+package seedu.address.ui;
+
+import java.util.logging.Logger;
+
+import javafx.collections.ObservableList;
+import javafx.fxml.FXML;
+import javafx.scene.control.ListCell;
+import javafx.scene.control.ListView;
+import javafx.scene.layout.Region;
+import seedu.address.commons.core.LogsCenter;
+import seedu.address.model.reminder.Reminder;
+
+/**
+ * Panel containing the list of reminders.
+ */
+public class ReminderListPanel extends UiPart<Region> {
+    private static final String FXML = "ReminderListPanel.fxml";
+    private final Logger logger = LogsCenter.getLogger(ReminderListPanel.class);
+
+    @FXML
+    private ListView<Reminder> reminderListView;
+
+    /**
+     * Creates a {@code ReminderListPanel} with the given {@code ObservableList}.
+     */
+    public ReminderListPanel(ObservableList<Reminder> reminderList) {
+        super(FXML);
+        reminderListView.setItems(reminderList);
+        reminderListView.setCellFactory(listView -> new ReminderListViewCell());
+    }
+
+    /**
+     * Custom {@code ListCell} that displays the graphics of a {@code Reminder} using a {@code ReminderCard}.
+     */
+    class ReminderListViewCell extends ListCell<Reminder> {
+        @Override
+        protected void updateItem(Reminder reminder, boolean empty) {
+            super.updateItem(reminder, empty);
+
+            if (empty || reminder == null) {
+                setGraphic(null);
+                setText(null);
+            } else {
+                setGraphic(new ReminderCard(reminder, getIndex() + 1).getRoot());
+            }
+        }
+    }
+
+}

--- a/src/main/resources/view/ChatBox.fxml
+++ b/src/main/resources/view/ChatBox.fxml
@@ -3,9 +3,11 @@
 <?import javafx.scene.control.ScrollPane?>
 <?import javafx.scene.layout.StackPane?>
 <?import javafx.scene.layout.VBox?>
-
-<StackPane fx:id="placeHolder" styleClass="pane-with-border" xmlns="http://javafx.com/javafx/11.0.1" xmlns:fx="http://javafx.com/fxml/1">
-    <ScrollPane fx:id="scrollPane" fitToWidth="true" hbarPolicy="NEVER" hvalue="0.0" maxHeight="-Infinity" maxWidth="Infinity" minHeight="-Infinity" minWidth="1024" prefHeight="150.0" vvalue="0.0" StackPane.alignment="TOP_LEFT">
-        <VBox fx:id="dialogContainer" minWidth="1024" prefHeight="150" styleClass="result-display" />
+<StackPane fx:id="placeHolder" styleClass="pane-with-border" xmlns="http://javafx.com/javafx/8"
+           xmlns:fx="http://javafx.com/fxml/1">
+    <ScrollPane fx:id="scrollPane" fitToWidth="true" hbarPolicy="NEVER" hvalue="0.0" maxHeight="-Infinity"
+                maxWidth="Infinity" minHeight="-Infinity" minWidth="1024" prefHeight="150.0" vvalue="0.0"
+                StackPane.alignment="TOP_LEFT">
+        <VBox fx:id="dialogContainer" minWidth="1024" prefHeight="150" styleClass="result-display"/>
     </ScrollPane>
 </StackPane>

--- a/src/main/resources/view/ChatBox.fxml
+++ b/src/main/resources/view/ChatBox.fxml
@@ -6,7 +6,7 @@
 <StackPane fx:id="placeHolder" styleClass="pane-with-border" xmlns="http://javafx.com/javafx/8"
            xmlns:fx="http://javafx.com/fxml/1">
     <ScrollPane fx:id="scrollPane" fitToWidth="true" hbarPolicy="NEVER" hvalue="0.0" maxHeight="-Infinity"
-                maxWidth="Infinity" minHeight="-Infinity" minWidth="1024" prefHeight="150.0" vvalue="0.0"
+                maxWidth="Infinity" minHeight="-Infinity" prefHeight="150.0" vvalue="0.0"
                 StackPane.alignment="TOP_LEFT">
         <VBox fx:id="dialogContainer" minWidth="1024" prefHeight="150" styleClass="result-display"/>
     </ScrollPane>

--- a/src/main/resources/view/HelpWindow.fxml
+++ b/src/main/resources/view/HelpWindow.fxml
@@ -1,4 +1,5 @@
-<?xml version="1.0" encoding="UTF-8"?><?import javafx.scene.control.Hyperlink?>
+<?xml version="1.0" encoding="UTF-8"?>
+<?import javafx.scene.control.Hyperlink?>
 <?import javafx.scene.control.Label?>
 <?import javafx.scene.control.ScrollPane?>
 <?import javafx.scene.image.Image?>
@@ -9,22 +10,18 @@
 <?import javafx.scene.text.Text?>
 <?import javafx.scene.text.TextFlow?>
 <?import javafx.stage.Stage?>
-<?import javafx.scene.Scene?>
-<?import javafx.scene.text.Text?>
-<?import javafx.scene.text.TextFlow?>
-<?import javafx.stage.Stage?>
-<?import javafx.scene.control.Hyperlink?>
-<fx:root resizable="false" title="Help" type="javafx.stage.Stage" xmlns="http://javafx.com/javafx/11" xmlns:fx="http://javafx.com/fxml/1">
-  <icons>
-    <Image url="@/images/help_icon.png" />
-  </icons>
-  <scene>
-    <Scene>
-        <ScrollPane hbarPolicy="NEVER" fitToWidth="true">
-        <HBox xmlns="http://javafx.com/javafx/8" xmlns:fx="http://javafx.com/fxml/1" style="-fx-background-color: derive(#1d1d1d, 20%);
+<fx:root resizable="false" title="Help" type="javafx.stage.Stage" xmlns="http://javafx.com/javafx/8"
+         xmlns:fx="http://javafx.com/fxml/1">
+    <icons>
+        <Image url="@/images/help_icon.png"/>
+    </icons>
+    <scene>
+        <Scene>
+            <ScrollPane hbarPolicy="NEVER" fitToWidth="true">
+                <HBox xmlns="http://javafx.com/javafx/8" xmlns:fx="http://javafx.com/fxml/1" style="-fx-background-color: derive(#1d1d1d, 20%);
          -fx-fillbackground-color: #383838;">
-            <GridPane fx:id="table" HBox.hgrow="ALWAYS">
-                <columnConstraints>
+                    <GridPane fx:id="table" HBox.hgrow="ALWAYS">
+                        <columnConstraints>
                     <ColumnConstraints hgrow="SOMETIMES" minWidth="10" prefWidth="150" />
                 </columnConstraints>
                 <TextFlow minWidth="-Infinity" GridPane.rowIndex="0" GridPane.columnIndex="0">

--- a/src/main/resources/view/MainWindow.fxml
+++ b/src/main/resources/view/MainWindow.fxml
@@ -2,14 +2,15 @@
 
 <?import java.net.URL?>
 <?import javafx.geometry.Insets?>
-<?import javafx.scene.Scene?>
 <?import javafx.scene.control.Menu?>
 <?import javafx.scene.control.MenuBar?>
 <?import javafx.scene.control.MenuItem?>
 <?import javafx.scene.image.Image?>
+<?import javafx.scene.layout.HBox?>
 <?import javafx.scene.layout.StackPane?>
 <?import javafx.scene.layout.VBox?>
-
+<?import javafx.scene.Scene?>
+<?import javafx.stage.Stage?>
 <fx:root type="javafx.stage.Stage" xmlns="http://javafx.com/javafx/8" xmlns:fx="http://javafx.com/fxml/1"
          title="Address App" minWidth="1024" minHeight="600" onCloseRequest="#handleExit">
   <icons>
@@ -25,24 +26,33 @@
       <VBox>
         <MenuBar fx:id="menuBar" VBox.vgrow="NEVER">
           <Menu mnemonicParsing="false" text="File">
-            <MenuItem mnemonicParsing="false" onAction="#handleExit" text="Exit" />
+            <MenuItem mnemonicParsing="false" onAction="#handleExit" text="Exit"/>
           </Menu>
           <Menu mnemonicParsing="false" text="Help">
-            <MenuItem fx:id="helpMenuItem" mnemonicParsing="false" onAction="#handleHelp" text="Help" />
+            <MenuItem fx:id="helpMenuItem" mnemonicParsing="false" onAction="#handleHelp" text="Help"/>
           </Menu>
         </MenuBar>
 
-        <VBox fx:id="personList" styleClass="pane-with-border" minWidth="340" prefWidth="1024" VBox.vgrow="ALWAYS">
-          <padding>
-            <Insets top="10" right="10" bottom="10" left="10" />
-          </padding>
-          <StackPane fx:id="personListPanelPlaceholder" VBox.vgrow="ALWAYS"/>
-        </VBox>
+        <HBox>
+          <VBox fx:id="personList" styleClass="pane-with-border" minWidth="340" prefWidth="1024" VBox.vgrow="ALWAYS">
+            <padding>
+              <Insets top="10" right="10" bottom="10" left="10"/>
+            </padding>
+            <StackPane fx:id="personListPanelPlaceholder" VBox.vgrow="ALWAYS"/>
+          </VBox>
+          <VBox fx:id="meetingList" styleClass="pane-with-border" minWidth="340" prefWidth="1024" VBox.vgrow="ALWAYS">
+            <padding>
+              <Insets top="10" right="10" bottom="10" left="10"/>
+            </padding>
+            <StackPane fx:id="meetingListPanelPlaceholder" VBox.vgrow="ALWAYS"/>
+          </VBox>
+        </HBox>
+
 
         <StackPane VBox.vgrow="NEVER" fx:id="chatBoxPlaceholder" styleClass="pane-with-border"
-                       minHeight="150" prefHeight="150" maxHeight="150" minWidth="340" prefWidth="1024">
+                   minHeight="150" prefHeight="150" maxHeight="150" minWidth="340" prefWidth="1024">
           <padding>
-            <Insets top="5" right="10" bottom="5" left="10" />
+            <Insets top="5" right="10" bottom="5" left="10"/>
           </padding>
         </StackPane>
 

--- a/src/main/resources/view/MainWindow.fxml
+++ b/src/main/resources/view/MainWindow.fxml
@@ -34,12 +34,28 @@
         </MenuBar>
 
         <HBox>
-          <VBox fx:id="personList" styleClass="pane-with-border" minWidth="340" prefWidth="1024" VBox.vgrow="ALWAYS">
-            <padding>
-              <Insets top="10" right="10" bottom="10" left="10"/>
-            </padding>
-            <StackPane fx:id="personListPanelPlaceholder" VBox.vgrow="ALWAYS"/>
+          <VBox>
+            <VBox fx:id="personList" styleClass="pane-with-border" minWidth="340" prefWidth="1024" VBox.vgrow="ALWAYS">
+              <padding>
+                <Insets top="10" right="10" bottom="10" left="10"/>
+              </padding>
+              <StackPane fx:id="personListPanelPlaceholder" VBox.vgrow="ALWAYS"/>
+            </VBox>
+
+            <StackPane VBox.vgrow="NEVER" fx:id="chatBoxPlaceholder" styleClass="pane-with-border"
+                       minHeight="150" prefHeight="150" maxHeight="150" minWidth="340" prefWidth="1024">
+              <padding>
+                <Insets top="5" right="10" bottom="5" left="10"/>
+              </padding>
+            </StackPane>
+
+            <StackPane VBox.vgrow="NEVER" fx:id="commandBoxPlaceholder" styleClass="pane-with-border">
+              <padding>
+                <Insets top="5" right="10" bottom="5" left="10"/>
+              </padding>
+            </StackPane>
           </VBox>
+
           <VBox>
             <VBox fx:id="meetingList" styleClass="pane-with-border" minWidth="340" prefWidth="512" VBox.vgrow="ALWAYS">
               <padding>
@@ -54,23 +70,18 @@
               </padding>
               <StackPane fx:id="reminderListPanelPlaceholder" VBox.vgrow="ALWAYS"/>
             </VBox>
+
+            <!-- This is a placeholder component that is to be deleted once the adhoc section is done -->
+            <VBox styleClass="pane-with-border" prefHeight="550" minWidth="340" prefWidth="512" VBox.vgrow="ALWAYS">
+              <padding>
+                <Insets top="10" right="10" bottom="10" left="10"/>
+              </padding>
+              <StackPane VBox.vgrow="ALWAYS"/>
+            </VBox>
           </VBox>
         </HBox>
 
-        <StackPane VBox.vgrow="NEVER" fx:id="chatBoxPlaceholder" styleClass="pane-with-border"
-                   minHeight="150" prefHeight="150" maxHeight="150" minWidth="340" prefWidth="1024">
-          <padding>
-            <Insets top="5" right="10" bottom="5" left="10"/>
-          </padding>
-        </StackPane>
-
-        <StackPane VBox.vgrow="NEVER" fx:id="commandBoxPlaceholder" styleClass="pane-with-border">
-          <padding>
-            <Insets top="5" right="10" bottom="5" left="10" />
-          </padding>
-        </StackPane>
-
-        <StackPane fx:id="statusbarPlaceholder" VBox.vgrow="NEVER" />
+        <StackPane fx:id="statusbarPlaceholder" VBox.vgrow="NEVER"/>
       </VBox>
     </Scene>
   </scene>

--- a/src/main/resources/view/MainWindow.fxml
+++ b/src/main/resources/view/MainWindow.fxml
@@ -12,15 +12,15 @@
 <?import javafx.scene.Scene?>
 <?import javafx.stage.Stage?>
 <fx:root type="javafx.stage.Stage" xmlns="http://javafx.com/javafx/8" xmlns:fx="http://javafx.com/fxml/1"
-         title="Address App" minWidth="1024" minHeight="600" onCloseRequest="#handleExit">
+         title="StonksBook" minWidth="900" minHeight="600" onCloseRequest="#handleExit">
   <icons>
-    <Image url="@/images/address_book_32.png" />
+    <Image url="@/images/address_book_32.png"/>
   </icons>
   <scene>
     <Scene>
       <stylesheets>
-        <URL value="@DarkTheme.css" />
-        <URL value="@Extensions.css" />
+        <URL value="@DarkTheme.css"/>
+        <URL value="@Extensions.css"/>
       </stylesheets>
 
       <VBox>

--- a/src/main/resources/view/MainWindow.fxml
+++ b/src/main/resources/view/MainWindow.fxml
@@ -56,15 +56,15 @@
             </StackPane>
           </VBox>
 
-          <VBox>
-            <VBox fx:id="meetingList" styleClass="pane-with-border" minWidth="340" prefWidth="512" VBox.vgrow="ALWAYS">
+          <VBox minWidth="340" prefWidth="768">
+            <VBox fx:id="meetingList" styleClass="pane-with-border" VBox.vgrow="ALWAYS">
               <padding>
                 <Insets top="10" right="10" bottom="10" left="10"/>
               </padding>
               <StackPane fx:id="meetingListPanelPlaceholder" VBox.vgrow="ALWAYS"/>
             </VBox>
 
-            <VBox fx:id="reminderList" styleClass="pane-with-border" minWidth="340" prefWidth="512" VBox.vgrow="ALWAYS">
+            <VBox fx:id="reminderList" styleClass="pane-with-border" VBox.vgrow="ALWAYS">
               <padding>
                 <Insets top="10" right="10" bottom="10" left="10"/>
               </padding>
@@ -72,7 +72,7 @@
             </VBox>
 
             <!-- This is a placeholder component that is to be deleted once the adhoc section is done -->
-            <VBox styleClass="pane-with-border" prefHeight="550" minWidth="340" prefWidth="512" VBox.vgrow="ALWAYS">
+            <VBox styleClass="pane-with-border" prefHeight="550" VBox.vgrow="ALWAYS">
               <padding>
                 <Insets top="10" right="10" bottom="10" left="10"/>
               </padding>

--- a/src/main/resources/view/MainWindow.fxml
+++ b/src/main/resources/view/MainWindow.fxml
@@ -40,14 +40,22 @@
             </padding>
             <StackPane fx:id="personListPanelPlaceholder" VBox.vgrow="ALWAYS"/>
           </VBox>
-          <VBox fx:id="meetingList" styleClass="pane-with-border" minWidth="340" prefWidth="512" VBox.vgrow="ALWAYS">
-            <padding>
-              <Insets top="10" right="10" bottom="10" left="10"/>
-            </padding>
-            <StackPane fx:id="meetingListPanelPlaceholder" VBox.vgrow="ALWAYS"/>
+          <VBox>
+            <VBox fx:id="meetingList" styleClass="pane-with-border" minWidth="340" prefWidth="512" VBox.vgrow="ALWAYS">
+              <padding>
+                <Insets top="10" right="10" bottom="10" left="10"/>
+              </padding>
+              <StackPane fx:id="meetingListPanelPlaceholder" VBox.vgrow="ALWAYS"/>
+            </VBox>
+
+            <VBox fx:id="reminderList" styleClass="pane-with-border" minWidth="340" prefWidth="512" VBox.vgrow="ALWAYS">
+              <padding>
+                <Insets top="10" right="10" bottom="10" left="10"/>
+              </padding>
+              <StackPane fx:id="reminderListPanelPlaceholder" VBox.vgrow="ALWAYS"/>
+            </VBox>
           </VBox>
         </HBox>
-
 
         <StackPane VBox.vgrow="NEVER" fx:id="chatBoxPlaceholder" styleClass="pane-with-border"
                    minHeight="150" prefHeight="150" maxHeight="150" minWidth="340" prefWidth="1024">

--- a/src/main/resources/view/MainWindow.fxml
+++ b/src/main/resources/view/MainWindow.fxml
@@ -40,7 +40,7 @@
             </padding>
             <StackPane fx:id="personListPanelPlaceholder" VBox.vgrow="ALWAYS"/>
           </VBox>
-          <VBox fx:id="meetingList" styleClass="pane-with-border" minWidth="340" prefWidth="1024" VBox.vgrow="ALWAYS">
+          <VBox fx:id="meetingList" styleClass="pane-with-border" minWidth="340" prefWidth="512" VBox.vgrow="ALWAYS">
             <padding>
               <Insets top="10" right="10" bottom="10" left="10"/>
             </padding>

--- a/src/main/resources/view/MeetingListCard.fxml
+++ b/src/main/resources/view/MeetingListCard.fxml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<?import javafx.geometry.Insets?>
+<?import javafx.scene.control.Label?>
+<?import javafx.scene.layout.ColumnConstraints?>
+<?import javafx.scene.layout.GridPane?>
+<?import javafx.scene.layout.HBox?>
+<?import javafx.scene.layout.Region?>
+<?import javafx.scene.layout.VBox?>
+<HBox id="cardPane" fx:id="cardPane" xmlns="http://javafx.com/javafx/8" xmlns:fx="http://javafx.com/fxml/1">
+  <GridPane HBox.hgrow="ALWAYS">
+    <columnConstraints>
+      <ColumnConstraints hgrow="SOMETIMES" minWidth="10" prefWidth="150"/>
+    </columnConstraints>
+    <VBox alignment="CENTER_LEFT" minHeight="105" GridPane.columnIndex="0">
+      <padding>
+        <Insets top="5" right="5" bottom="5" left="15"/>
+      </padding>
+      <HBox spacing="5" alignment="CENTER_LEFT">
+        <Label fx:id="id" styleClass="cell_big_label">
+          <minWidth>
+            <!-- Ensures that the label text is never truncated -->
+            <Region fx:constant="USE_PREF_SIZE"/>
+          </minWidth>
+        </Label>
+        <Label fx:id="message" text="\$first" styleClass="cell_big_label"/>
+      </HBox>
+      <Label fx:id="startDate" styleClass="cell_small_label" text="\$startDate"/>
+      <Label fx:id="endDate" styleClass="cell_small_label" text="\$endDate"/>
+      <Label fx:id="personName" styleClass="cell_small_label" text="\$personName"/>
+    </VBox>
+  </GridPane>
+</HBox>

--- a/src/main/resources/view/MeetingListCard.fxml
+++ b/src/main/resources/view/MeetingListCard.fxml
@@ -13,7 +13,7 @@
     <columnConstraints>
       <ColumnConstraints hgrow="SOMETIMES" minWidth="10" prefWidth="150"/>
     </columnConstraints>
-    <VBox spacing="5" alignment="CENTER_LEFT" minHeight="105" GridPane.columnIndex="0">
+    <VBox spacing="5" alignment="CENTER_LEFT" minHeight="85" GridPane.columnIndex="0">
       <padding>
         <Insets top="5" right="5" bottom="5" left="15"/>
       </padding>

--- a/src/main/resources/view/MeetingListCard.fxml
+++ b/src/main/resources/view/MeetingListCard.fxml
@@ -17,22 +17,22 @@
       <padding>
         <Insets top="5" right="5" bottom="5" left="15"/>
       </padding>
-      <HBox spacing="5" alignment="CENTER_LEFT">
+      <HBox spacing="5">
         <Label fx:id="id" styleClass="cell_big_label">
           <minWidth>
             <!-- Ensures that the label text is never truncated -->
             <Region fx:constant="USE_PREF_SIZE"/>
           </minWidth>
         </Label>
-        <Label fx:id="message" text="\$first" styleClass="cell_big_label"/>
+        <Label fx:id="message" text="\$first" wrapText="true" styleClass="cell_big_label"/>
       </HBox>
       <HBox spacing="5" alignment="CENTER_LEFT">
         <FontIcon iconLiteral="far-calendar-alt" iconColor="white" iconSize="16"/>
-        <Label fx:id="date" styleClass="cell_small_label" text="\$date"/>
+        <Label fx:id="date" styleClass="cell_small_label" text="\$date" wrapText="true"/>
       </HBox>
       <HBox spacing="5" alignment="CENTER_LEFT">
         <FontIcon iconLiteral="fas-user-circle" iconColor="white" iconSize="16"/>
-        <Label fx:id="personName" styleClass="cell_small_label" text="\$personName"/>
+        <Label fx:id="personName" styleClass="cell_small_label" text="\$personName" wrapText="true"/>
       </HBox>
     </VBox>
   </GridPane>

--- a/src/main/resources/view/MeetingListCard.fxml
+++ b/src/main/resources/view/MeetingListCard.fxml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
+<?import org.kordamp.ikonli.javafx.FontIcon?>
 <?import javafx.geometry.Insets?>
 <?import javafx.scene.control.Label?>
 <?import javafx.scene.layout.ColumnConstraints?>
@@ -12,7 +13,7 @@
     <columnConstraints>
       <ColumnConstraints hgrow="SOMETIMES" minWidth="10" prefWidth="150"/>
     </columnConstraints>
-    <VBox alignment="CENTER_LEFT" minHeight="105" GridPane.columnIndex="0">
+    <VBox spacing="5" alignment="CENTER_LEFT" minHeight="105" GridPane.columnIndex="0">
       <padding>
         <Insets top="5" right="5" bottom="5" left="15"/>
       </padding>
@@ -25,9 +26,14 @@
         </Label>
         <Label fx:id="message" text="\$first" styleClass="cell_big_label"/>
       </HBox>
-      <Label fx:id="startDate" styleClass="cell_small_label" text="\$startDate"/>
-      <Label fx:id="endDate" styleClass="cell_small_label" text="\$endDate"/>
-      <Label fx:id="personName" styleClass="cell_small_label" text="\$personName"/>
+      <HBox spacing="5" alignment="CENTER_LEFT">
+        <FontIcon iconLiteral="far-calendar-alt" iconColor="white" iconSize="16"/>
+        <Label fx:id="date" styleClass="cell_small_label" text="\$date"/>
+      </HBox>
+      <HBox spacing="5" alignment="CENTER_LEFT">
+        <FontIcon iconLiteral="fas-user-circle" iconColor="white" iconSize="16"/>
+        <Label fx:id="personName" styleClass="cell_small_label" text="\$personName"/>
+      </HBox>
     </VBox>
   </GridPane>
 </HBox>

--- a/src/main/resources/view/MeetingListPanel.fxml
+++ b/src/main/resources/view/MeetingListPanel.fxml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<?import javafx.scene.control.ListView?>
+<?import javafx.scene.layout.VBox?>
+<VBox xmlns="http://javafx.com/javafx/8" xmlns:fx="http://javafx.com/fxml/1">
+  <ListView fx:id="meetingListView" VBox.vgrow="ALWAYS"/>
+</VBox>

--- a/src/main/resources/view/ReminderListCard.fxml
+++ b/src/main/resources/view/ReminderListCard.fxml
@@ -13,7 +13,7 @@
     <columnConstraints>
       <ColumnConstraints hgrow="SOMETIMES" minWidth="10" prefWidth="150"/>
     </columnConstraints>
-    <VBox spacing="5" alignment="CENTER_LEFT" minHeight="105" GridPane.columnIndex="0">
+    <VBox spacing="5" alignment="CENTER_LEFT" minHeight="85" GridPane.columnIndex="0">
       <padding>
         <Insets top="5" right="5" bottom="5" left="15"/>
       </padding>

--- a/src/main/resources/view/ReminderListCard.fxml
+++ b/src/main/resources/view/ReminderListCard.fxml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<?import org.kordamp.ikonli.javafx.FontIcon?>
+<?import javafx.geometry.Insets?>
+<?import javafx.scene.control.Label?>
+<?import javafx.scene.layout.ColumnConstraints?>
+<?import javafx.scene.layout.GridPane?>
+<?import javafx.scene.layout.HBox?>
+<?import javafx.scene.layout.Region?>
+<?import javafx.scene.layout.VBox?>
+<HBox id="cardPane" fx:id="cardPane" xmlns="http://javafx.com/javafx/8" xmlns:fx="http://javafx.com/fxml/1">
+  <GridPane HBox.hgrow="ALWAYS">
+    <columnConstraints>
+      <ColumnConstraints hgrow="SOMETIMES" minWidth="10" prefWidth="150"/>
+    </columnConstraints>
+    <VBox spacing="5" alignment="CENTER_LEFT" minHeight="105" GridPane.columnIndex="0">
+      <padding>
+        <Insets top="5" right="5" bottom="5" left="15"/>
+      </padding>
+      <HBox spacing="5">
+        <Label fx:id="id" styleClass="cell_big_label">
+          <minWidth>
+            <!-- Ensures that the label text is never truncated -->
+            <Region fx:constant="USE_PREF_SIZE"/>
+          </minWidth>
+        </Label>
+        <Label fx:id="message" text="\$first" wrapText="true" styleClass="cell_big_label"/>
+      </HBox>
+      <HBox spacing="5" alignment="CENTER_LEFT">
+        <FontIcon iconLiteral="far-calendar-alt" iconColor="white" iconSize="16"/>
+        <Label fx:id="scheduledDate" styleClass="cell_small_label" text="\$scheduledDate" wrapText="true"/>
+      </HBox>
+      <HBox spacing="5" alignment="CENTER_LEFT">
+        <FontIcon iconLiteral="fas-user-circle" iconColor="white" iconSize="16"/>
+        <Label fx:id="personName" styleClass="cell_small_label" text="\$personName" wrapText="true"/>
+      </HBox>
+    </VBox>
+  </GridPane>
+</HBox>

--- a/src/main/resources/view/ReminderListPanel.fxml
+++ b/src/main/resources/view/ReminderListPanel.fxml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<?import javafx.scene.control.ListView?>
+<?import javafx.scene.layout.VBox?>
+<VBox xmlns="http://javafx.com/javafx/8" xmlns:fx="http://javafx.com/fxml/1">
+  <ListView fx:id="reminderListView" VBox.vgrow="ALWAYS"/>
+</VBox>

--- a/src/test/java/seedu/address/commons/util/DateUtilTest.java
+++ b/src/test/java/seedu/address/commons/util/DateUtilTest.java
@@ -1,0 +1,31 @@
+package seedu.address.commons.util;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.address.commons.util.DateUtil.isSameDay;
+
+import java.time.LocalDateTime;
+
+import org.junit.jupiter.api.Test;
+
+public class DateUtilTest {
+    @Test
+    public void isSameDay_sameObjects_returnTrue() {
+        LocalDateTime date = LocalDateTime.of(2020, 10, 10, 10, 10, 10);
+        assertTrue(isSameDay(date, date));
+    }
+
+    @Test
+    public void isSameDay_sameDayDiffHour_returnTrue() {
+        LocalDateTime date1 = LocalDateTime.of(2020, 10, 10, 10, 10, 10);
+        LocalDateTime date2 = LocalDateTime.of(2020, 10, 10, 0, 10, 10);
+        assertTrue(isSameDay(date1, date2));
+    }
+
+    @Test
+    public void isSameDay_sameDayDiffYear_returnFalse() {
+        LocalDateTime date1 = LocalDateTime.of(2020, 10, 10, 10, 10, 10);
+        LocalDateTime date2 = LocalDateTime.of(2019, 10, 10, 10, 10, 10);
+        assertFalse(isSameDay(date1, date2));
+    }
+}


### PR DESCRIPTION
Closes #108

- Added MeetingCard, MeetingListPanel, ReminderCard, ReminderListPanel components
- Updated overall layout of GUI
- Added a new dependency `org.kordamp.ikonli:ikonli-fontawesome5-pack:11.5.0` for the use of icons in the application. Also added the corresponding acknowledgements
  - Permission obtained here: https://github.com/nus-cs2103-AY2021S1/forum/issues/311
- Updated date formatting of Meeting to be more concise. If the meeting spans entirely within the same day, the date will not be duplicated when displaying the start and end date e.g. `Fri, 20 Nov 2020, 15:30 - 16:00`. Otherwise, the date will be something like `Tue, 01 Oct 2019, 10:00 - Sun, 06 Oct 2019, 10:00`
- Fixed some warnings regarding javafx version 
- Updated min width of main window to be 900, and set the title of the window to be `StonksBook`

Demo: 
![image](https://user-images.githubusercontent.com/24363622/96137858-bcc77580-0f2f-11eb-9a76-766ceb270d01.png)

