### PR TITLE
Visual indicator for overdue reminders and test cases for meetings and reminders commands

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -73,4 +73,8 @@ shadowJar {
     mergeServiceFiles()
 }
 
+run {
+    enableAssertions = true
+}
+
 defaultTasks 'clean', 'test'

--- a/src/main/java/seedu/address/logic/commands/reminder/ListCommand.java
+++ b/src/main/java/seedu/address/logic/commands/reminder/ListCommand.java
@@ -2,15 +2,9 @@ package seedu.address.logic.commands.reminder;
 
 import static java.util.Objects.requireNonNull;
 
-import java.util.List;
-import java.util.stream.Collectors;
-import java.util.stream.IntStream;
-
-import seedu.address.commons.core.index.Index;
 import seedu.address.logic.commands.Command;
 import seedu.address.logic.commands.CommandResult;
 import seedu.address.model.Model;
-import seedu.address.model.reminder.Reminder;
 
 /**
  * Lists all reminders in the address book to the user.
@@ -24,19 +18,8 @@ public class ListCommand extends Command {
     @Override
     public CommandResult execute(Model model) {
         requireNonNull(model);
-        List<Reminder> reminders = model.getSortedReminderList();
 
-        String output;
-        if (reminders.size() == 0) {
-            output = "No reminders found!";
-        } else {
-            output = IntStream
-                    .range(0, reminders.size())
-                    .mapToObj(i -> String.format("%d. %s", Index.fromZeroBased(i).getOneBased(), reminders.get(i)))
-                    .collect(Collectors.joining("\n"));
-        }
-
-        return new CommandResult(output);
+        return new CommandResult(MESSAGE_SUCCESS);
     }
 
     @Override

--- a/src/main/java/seedu/address/model/reminder/Reminder.java
+++ b/src/main/java/seedu/address/model/reminder/Reminder.java
@@ -54,6 +54,14 @@ public class Reminder implements Comparable<Reminder> {
         return getScheduledDate().format(DATE_TIME_FORMATTER);
     }
 
+    /**
+     * Returns true if the reminder is not yet complete and the scheduled date is past the current date.
+     * TODO: Add check that the reminder is not yet complete
+     */
+    public boolean isOverdue() {
+        return this.getScheduledDate().isBefore(LocalDateTime.now());
+    }
+
     @Override
     public String toString() {
         final StringBuilder builder = new StringBuilder();

--- a/src/main/java/seedu/address/ui/MainWindow.java
+++ b/src/main/java/seedu/address/ui/MainWindow.java
@@ -207,6 +207,12 @@ public class MainWindow extends UiPart<Stage> {
                 chatBox.clear();
             }
 
+            // Force refresh of the following UI components which are time sensitive
+            // Overdue reminders should be displayed differently
+            this.reminderListPanel.refresh();
+            // Past meetings should be filtered out
+            this.meetingListPanel.refresh();
+
             return commandResult;
         } catch (CommandException | ParseException e) {
             logger.info("Invalid command: " + commandText);

--- a/src/main/java/seedu/address/ui/MeetingListPanel.java
+++ b/src/main/java/seedu/address/ui/MeetingListPanel.java
@@ -30,6 +30,13 @@ public class MeetingListPanel extends UiPart<Region> {
     }
 
     /**
+     * Refreshes (redraws) the MeetingListPanel. Use when you want to force an update of the UI.
+     */
+    public void refresh() {
+        this.meetingListView.refresh();
+    }
+
+    /**
      * Custom {@code ListCell} that displays the graphics of a {@code Meeting} using a {@code MeetingCard}.
      */
     class MeetingListViewCell extends ListCell<Meeting> {

--- a/src/main/java/seedu/address/ui/ReminderCard.java
+++ b/src/main/java/seedu/address/ui/ReminderCard.java
@@ -15,10 +15,9 @@ import seedu.address.model.reminder.Reminder;
  */
 public class ReminderCard extends UiPart<Region> {
 
-    // The shae of red that is used to indicate overdue reminders
+    // The shade of red that is used to indicate overdue reminders
     private static final String RED = "#ff0266";
-
-    private static final String OVERDUE_DATE_STYLE_CLASS = "overdue-date";
+    private static final String OVERDUE_DATE_STYLE_CLASS = "overdue";
     private static final String FXML = "ReminderListCard.fxml";
 
     public final Reminder reminder;

--- a/src/main/java/seedu/address/ui/ReminderCard.java
+++ b/src/main/java/seedu/address/ui/ReminderCard.java
@@ -1,9 +1,13 @@
 package seedu.address.ui;
 
+import org.kordamp.ikonli.javafx.FontIcon;
+
+import javafx.collections.ObservableList;
 import javafx.fxml.FXML;
 import javafx.scene.control.Label;
 import javafx.scene.layout.HBox;
 import javafx.scene.layout.Region;
+import javafx.scene.paint.Paint;
 import seedu.address.model.reminder.Reminder;
 
 /**
@@ -11,6 +15,10 @@ import seedu.address.model.reminder.Reminder;
  */
 public class ReminderCard extends UiPart<Region> {
 
+    // The shae of red that is used to indicate overdue reminders
+    private static final String RED = "#ff0266";
+
+    private static final String OVERDUE_DATE_STYLE_CLASS = "overdue-date";
     private static final String FXML = "ReminderListCard.fxml";
 
     public final Reminder reminder;
@@ -25,6 +33,8 @@ public class ReminderCard extends UiPart<Region> {
     private Label scheduledDate;
     @FXML
     private Label personName;
+    @FXML
+    private FontIcon calendarIcon;
 
     /**
      * Creates a {@code ReminderCard} with the given {@code Reminder} and index to display.
@@ -36,6 +46,23 @@ public class ReminderCard extends UiPart<Region> {
         message.setText(reminder.getMessage());
         scheduledDate.setText(reminder.getFormattedScheduledDate());
         personName.setText(reminder.getPerson().getName().fullName);
+
+        //  TODO: Test that the colour updates properly when a reminder is updated
+        if (reminder.isOverdue()) {
+            setStyleToIndicateOverdue();
+        }
+    }
+
+    /**
+     * Sets the reminder card style to indicate an overdue reminder.
+     */
+    private void setStyleToIndicateOverdue() {
+        calendarIcon.setIconColor(Paint.valueOf(RED));
+
+        ObservableList<String> scheduledDateStyleClass = scheduledDate.getStyleClass();
+        if (!scheduledDateStyleClass.contains(OVERDUE_DATE_STYLE_CLASS)) {
+            scheduledDateStyleClass.add(OVERDUE_DATE_STYLE_CLASS);
+        }
     }
 
     @Override

--- a/src/main/java/seedu/address/ui/ReminderListPanel.java
+++ b/src/main/java/seedu/address/ui/ReminderListPanel.java
@@ -30,6 +30,13 @@ public class ReminderListPanel extends UiPart<Region> {
     }
 
     /**
+     * Refreshes (redraws) the ReminderListPanel. Use when you want to force an update of the UI.
+     */
+    void refresh() {
+        this.reminderListView.refresh();
+    }
+
+    /**
      * Custom {@code ListCell} that displays the graphics of a {@code Reminder} using a {@code ReminderCard}.
      */
     class ReminderListViewCell extends ListCell<Reminder> {

--- a/src/main/resources/view/Extensions.css
+++ b/src/main/resources/view/Extensions.css
@@ -1,3 +1,6 @@
+.overdue-date {
+    -fx-text-fill: #ff0266 !important; /* The error class should always override the default text-fill style */
+}
 
 .error {
     -fx-text-fill: #d06651 !important; /* The error class should always override the default text-fill style */

--- a/src/main/resources/view/Extensions.css
+++ b/src/main/resources/view/Extensions.css
@@ -1,5 +1,5 @@
-.overdue-date {
-    -fx-text-fill: #ff0266 !important; /* The error class should always override the default text-fill style */
+.overdue {
+    -fx-text-fill: #ff0266 !important; /* The overdue class should always override the default text-fill style */
 }
 
 .error {

--- a/src/main/resources/view/ReminderListCard.fxml
+++ b/src/main/resources/view/ReminderListCard.fxml
@@ -27,7 +27,7 @@
         <Label fx:id="message" text="\$first" wrapText="true" styleClass="cell_big_label"/>
       </HBox>
       <HBox spacing="5" alignment="CENTER_LEFT">
-        <FontIcon iconLiteral="far-calendar-alt" iconColor="white" iconSize="16"/>
+        <FontIcon fx:id="calendarIcon" iconLiteral="far-calendar-alt" iconColor="white" iconSize="16"/>
         <Label fx:id="scheduledDate" styleClass="cell_small_label" text="\$scheduledDate" wrapText="true"/>
       </HBox>
       <HBox spacing="5" alignment="CENTER_LEFT">

--- a/src/test/java/seedu/address/logic/commands/contact/AddCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/contact/AddCommandTest.java
@@ -6,27 +6,17 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.address.testutil.Assert.assertThrows;
 
-import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Comparator;
-import java.util.function.Predicate;
 
 import org.junit.jupiter.api.Test;
 
-import javafx.collections.ObservableList;
-import seedu.address.commons.core.GuiSettings;
 import seedu.address.logic.commands.CommandResult;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.AddressBook;
-import seedu.address.model.Model;
+import seedu.address.model.ModelStub;
 import seedu.address.model.ReadOnlyAddressBook;
-import seedu.address.model.ReadOnlyUserPrefs;
-import seedu.address.model.meeting.Meeting;
 import seedu.address.model.person.Person;
-import seedu.address.model.reminder.Reminder;
-import seedu.address.model.sale.Sale;
-import seedu.address.model.tag.Tag;
 import seedu.address.testutil.person.PersonBuilder;
 
 public class AddCommandTest {
@@ -78,200 +68,6 @@ public class AddCommandTest {
 
         // different person -> returns false
         assertFalse(addAliceCommand.equals(addBobCommand));
-    }
-
-    /**
-     * A default model stub that have all of the methods failing.
-     */
-    private class ModelStub implements Model {
-        @Override
-        public void setUserPrefs(ReadOnlyUserPrefs userPrefs) {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public ReadOnlyUserPrefs getUserPrefs() {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public GuiSettings getGuiSettings() {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public void setGuiSettings(GuiSettings guiSettings) {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public Path getAddressBookFilePath() {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public void setAddressBookFilePath(Path addressBookFilePath) {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public void addPerson(Person person) {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public void setAddressBook(ReadOnlyAddressBook newData) {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public ReadOnlyAddressBook getAddressBook() {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public boolean hasPerson(Person person) {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public boolean hasContactTag(Tag tag) {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public boolean hasSaleTag(Tag tag) {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public void addContactTag(Tag tag) {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public void editContactTag(Tag target, Tag editedTag) {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public void editSaleTag(Tag target, Tag editedTag) {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public void deleteContactTag(Tag target) {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public void deleteSaleTag(Tag target) {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public int findByContactTag(Tag target) {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public String findBySaleTag(Tag target) {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public String listTags() {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public ObservableList<Tag> getContactTagList() {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public ObservableList<Tag> getSaleTagList() {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public void deletePerson(Person target) {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public void setPerson(Person target, Person editedPerson) {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public ObservableList<Person> getFilteredPersonList() {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public void updateFilteredPersonList(Predicate<Person> predicate) {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public ObservableList<Person> getSortedPersonList() {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        public void updateSortedPersonList(Comparator<Person> comparator) {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public ObservableList<Meeting> getSortedMeetingList() {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public boolean hasMeeting(Meeting meeting) {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public void deleteMeeting(Meeting target) {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public void addMeeting(Meeting meeting) {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public ObservableList<Reminder> getSortedReminderList() {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public boolean hasReminder(Reminder reminder) {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public void deleteReminder(Reminder target) {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public void addReminder(Reminder reminder) {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public void addSaleToPerson(Person person, Sale sale) {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public void removeSaleFromPerson(Person person, Sale sale) {
-            throw new AssertionError("This method should not be called.");
-        }
     }
 
     /**

--- a/src/test/java/seedu/address/logic/commands/meeting/AddCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/meeting/AddCommandTest.java
@@ -1,0 +1,154 @@
+package seedu.address.logic.commands.meeting;
+
+import static java.util.Objects.requireNonNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static seedu.address.testutil.Assert.assertThrows;
+import static seedu.address.testutil.TypicalDates.TYPICAL_DATE_1;
+import static seedu.address.testutil.TypicalDates.TYPICAL_DATE_2;
+import static seedu.address.testutil.TypicalDurations.TYPICAL_DURATION_HALF_HOUR;
+import static seedu.address.testutil.TypicalDurations.TYPICAL_DURATION_ONE_HOUR;
+import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_ITEM;
+import static seedu.address.testutil.TypicalIndexes.INDEX_SECOND_ITEM;
+import static seedu.address.testutil.person.TypicalPersons.BOB;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.logic.commands.CommandResult;
+import seedu.address.logic.commands.exceptions.CommandException;
+import seedu.address.model.ModelStub;
+import seedu.address.model.ModelStubWithSortedPersonList;
+import seedu.address.model.meeting.Meeting;
+import seedu.address.model.person.Person;
+import seedu.address.testutil.person.PersonBuilder;
+
+public class AddCommandTest {
+    private static final String MESSAGE = "message";
+
+    @Test
+    public void constructor_nullIndex_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () ->
+                new AddCommand(null, MESSAGE, TYPICAL_DATE_1, TYPICAL_DURATION_ONE_HOUR));
+    }
+
+    @Test
+    public void constructor_nullMessage_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () ->
+                new AddCommand(INDEX_FIRST_ITEM, null, TYPICAL_DATE_1, TYPICAL_DURATION_ONE_HOUR));
+    }
+
+    @Test
+    public void constructor_nullStartDate_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () ->
+                new AddCommand(INDEX_FIRST_ITEM, MESSAGE, null, TYPICAL_DURATION_ONE_HOUR));
+    }
+
+    @Test
+    public void constructor_nullDuration_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () ->
+                new AddCommand(INDEX_FIRST_ITEM, MESSAGE, TYPICAL_DATE_1, null));
+    }
+
+    @Test
+    public void execute_meetingAcceptedByModel_addSuccessful() throws Exception {
+        ModelStubAcceptingMeetingAdded modelStub = new ModelStubAcceptingMeetingAdded();
+        Person validPerson = new PersonBuilder(BOB).build();
+
+        Meeting meeting = new Meeting(validPerson, MESSAGE, TYPICAL_DATE_1, TYPICAL_DURATION_ONE_HOUR);
+        CommandResult commandResult =
+                new AddCommand(INDEX_FIRST_ITEM, MESSAGE, TYPICAL_DATE_1, TYPICAL_DURATION_ONE_HOUR)
+                        .execute(modelStub);
+
+        assertEquals(String.format(AddCommand.MESSAGE_SUCCESS, meeting), commandResult.getFeedbackToUser());
+        assertEquals(Arrays.asList(meeting), modelStub.meetingsAdded);
+    }
+
+    @Test
+    public void execute_duplicateMeeting_throwsCommandException() {
+        Person validPerson = new PersonBuilder(BOB).build();
+        Meeting meeting = new Meeting(validPerson, MESSAGE, TYPICAL_DATE_1, TYPICAL_DURATION_ONE_HOUR);
+        ModelStub modelStub = new ModelStubWithMeeting(meeting);
+
+        AddCommand addCommand = new AddCommand(INDEX_FIRST_ITEM, MESSAGE, TYPICAL_DATE_1, TYPICAL_DURATION_ONE_HOUR);
+        assertThrows(CommandException.class, AddCommand.MESSAGE_DUPLICATE_MEETING, () ->
+                addCommand.execute(modelStub));
+    }
+
+    @Test
+    public void equals() {
+        AddCommand addLunchAliceMeetingCommand =
+                new AddCommand(INDEX_FIRST_ITEM, "Lunch with Alice", TYPICAL_DATE_1, TYPICAL_DURATION_ONE_HOUR);
+
+        // same object -> returns true
+        assertEquals(addLunchAliceMeetingCommand, addLunchAliceMeetingCommand);
+
+        // same values -> returns true
+        AddCommand addLunchAliceMeetingCommandCopy =
+                new AddCommand(INDEX_FIRST_ITEM, "Lunch with Alice", TYPICAL_DATE_1, TYPICAL_DURATION_ONE_HOUR);
+        assertEquals(addLunchAliceMeetingCommand, addLunchAliceMeetingCommandCopy);
+
+        // different types -> returns false
+        assertNotEquals(addLunchAliceMeetingCommand, 1);
+
+        // null -> returns false
+        assertNotEquals(addLunchAliceMeetingCommand, null);
+
+        // different index -> returns false
+        assertNotEquals(addLunchAliceMeetingCommand,
+                new AddCommand(INDEX_SECOND_ITEM, "Lunch with Alice", TYPICAL_DATE_1, TYPICAL_DURATION_ONE_HOUR));
+
+        // different message -> returns false
+        assertNotEquals(addLunchAliceMeetingCommand,
+                new AddCommand(INDEX_FIRST_ITEM, "Dinner with Alice", TYPICAL_DATE_1, TYPICAL_DURATION_ONE_HOUR));
+
+        // different date -> returns false
+        assertNotEquals(addLunchAliceMeetingCommand,
+                new AddCommand(INDEX_FIRST_ITEM, "Lunch with Alice", TYPICAL_DATE_2, TYPICAL_DURATION_ONE_HOUR));
+
+        // different duration -> returns false
+        assertNotEquals(addLunchAliceMeetingCommand,
+                new AddCommand(INDEX_FIRST_ITEM, "Lunch with Alice", TYPICAL_DATE_1, TYPICAL_DURATION_HALF_HOUR));
+    }
+
+    /**
+     * A Model stub that always accept the meeting being added.
+     */
+    private class ModelStubAcceptingMeetingAdded extends ModelStubWithSortedPersonList {
+        final ArrayList<Meeting> meetingsAdded = new ArrayList<>();
+
+        @Override
+        public boolean hasMeeting(Meeting meeting) {
+            requireNonNull(meeting);
+            return meetingsAdded.stream().anyMatch(meeting::equals);
+        }
+
+        @Override
+        public void addMeeting(Meeting meeting) {
+            requireNonNull(meeting);
+            assert meeting.getPerson().equals(BOB);
+
+            meetingsAdded.add(meeting);
+        }
+    }
+
+    /**
+     * A Model stub that contains a single meeting.
+     */
+    private class ModelStubWithMeeting extends ModelStubWithSortedPersonList {
+        private final Meeting meeting;
+
+        ModelStubWithMeeting(Meeting meeting) {
+            requireNonNull(meeting);
+            this.meeting = meeting;
+        }
+
+        @Override
+        public boolean hasMeeting(Meeting meeting) {
+            requireNonNull(meeting);
+            return this.meeting.equals(meeting);
+        }
+    }
+}

--- a/src/test/java/seedu/address/logic/commands/meeting/AddCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/meeting/AddCommandTest.java
@@ -128,8 +128,6 @@ public class AddCommandTest {
         @Override
         public void addMeeting(Meeting meeting) {
             requireNonNull(meeting);
-            assert meeting.getPerson().equals(BOB);
-
             meetingsAdded.add(meeting);
         }
     }

--- a/src/test/java/seedu/address/logic/commands/meeting/DeleteCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/meeting/DeleteCommandTest.java
@@ -36,7 +36,7 @@ public class DeleteCommandTest {
 
     @Test
     public void execute_invalidIndexUnfilteredList_throwsCommandException() {
-        Index outOfBoundIndex = Index.fromOneBased(model.getSortedReminderList().size() + 1);
+        Index outOfBoundIndex = Index.fromOneBased(model.getSortedMeetingList().size() + 1);
         DeleteCommand deleteCommand = new DeleteCommand(outOfBoundIndex);
 
         assertCommandFailure(deleteCommand, model, Messages.MESSAGE_INVALID_MEETING_DISPLAYED_INDEX);
@@ -60,7 +60,7 @@ public class DeleteCommandTest {
         // null -> returns false
         assertNotEquals(deleteFirstCommand, null);
 
-        // different reminders -> returns false
+        // different indices -> returns false
         assertNotEquals(deleteFirstCommand, deleteSecondCommand);
     }
 }

--- a/src/test/java/seedu/address/logic/commands/meeting/DeleteCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/meeting/DeleteCommandTest.java
@@ -1,0 +1,66 @@
+package seedu.address.logic.commands.meeting;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static seedu.address.logic.commands.CommandTestUtil.assertCommandFailure;
+import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
+import static seedu.address.testutil.TypicalAddressBook.getTypicalAddressBook;
+import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_ITEM;
+import static seedu.address.testutil.TypicalIndexes.INDEX_SECOND_ITEM;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.commons.core.Messages;
+import seedu.address.commons.core.index.Index;
+import seedu.address.model.Model;
+import seedu.address.model.ModelManager;
+import seedu.address.model.UserPrefs;
+import seedu.address.model.meeting.Meeting;
+
+public class DeleteCommandTest {
+
+    private Model model = new ModelManager(getTypicalAddressBook(), new UserPrefs());
+
+    @Test
+    public void execute_validIndexUnfilteredList_success() {
+        Meeting meetingToDelete = model.getSortedMeetingList().get(INDEX_FIRST_ITEM.getZeroBased());
+        DeleteCommand deleteCommand = new DeleteCommand(INDEX_FIRST_ITEM);
+
+        String expectedMessage = String.format(DeleteCommand.MESSAGE_DELETE_MEETING_SUCCESS, meetingToDelete);
+
+        ModelManager expectedModel = new ModelManager(model.getAddressBook(), new UserPrefs());
+        expectedModel.deleteMeeting(meetingToDelete);
+
+        assertCommandSuccess(deleteCommand, model, expectedMessage, expectedModel);
+    }
+
+    @Test
+    public void execute_invalidIndexUnfilteredList_throwsCommandException() {
+        Index outOfBoundIndex = Index.fromOneBased(model.getSortedReminderList().size() + 1);
+        DeleteCommand deleteCommand = new DeleteCommand(outOfBoundIndex);
+
+        assertCommandFailure(deleteCommand, model, Messages.MESSAGE_INVALID_MEETING_DISPLAYED_INDEX);
+    }
+
+    @Test
+    public void equals() {
+        DeleteCommand deleteFirstCommand = new DeleteCommand(INDEX_FIRST_ITEM);
+        DeleteCommand deleteSecondCommand = new DeleteCommand(INDEX_SECOND_ITEM);
+
+        // same object -> returns true
+        assertEquals(deleteFirstCommand, deleteFirstCommand);
+
+        // same values -> returns true
+        DeleteCommand deleteFirstCommandCopy = new DeleteCommand(INDEX_FIRST_ITEM);
+        assertEquals(deleteFirstCommand, deleteFirstCommandCopy);
+
+        // different types -> returns false
+        assertNotEquals(deleteFirstCommand, 1);
+
+        // null -> returns false
+        assertNotEquals(deleteFirstCommand, null);
+
+        // different reminders -> returns false
+        assertNotEquals(deleteFirstCommand, deleteSecondCommand);
+    }
+}

--- a/src/test/java/seedu/address/logic/commands/meeting/ListCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/meeting/ListCommandTest.java
@@ -1,0 +1,39 @@
+package seedu.address.logic.commands.meeting;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
+import static seedu.address.testutil.TypicalAddressBook.getTypicalAddressBook;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import seedu.address.model.Model;
+import seedu.address.model.ModelManager;
+import seedu.address.model.UserPrefs;
+
+/**
+ * Contains integration tests (interaction with the Model) and unit tests for ListCommand.
+ */
+public class ListCommandTest {
+
+    private Model model;
+    private Model expectedModel;
+
+    @BeforeEach
+    public void setUp() {
+        model = new ModelManager(getTypicalAddressBook(), new UserPrefs());
+        expectedModel = new ModelManager(model.getAddressBook(), new UserPrefs());
+    }
+
+    @Test
+    public void execute_listIsNotFiltered_showsSameList() {
+        assertCommandSuccess(new ListCommand(), model, ListCommand.MESSAGE_SUCCESS, expectedModel);
+    }
+
+    @Test
+    public void equals() {
+        ListCommand listFirstCommand = new ListCommand();
+        ListCommand listSecondCommand = new ListCommand();
+        assertEquals(listFirstCommand, listSecondCommand);
+    }
+}

--- a/src/test/java/seedu/address/logic/commands/reminder/AddCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/reminder/AddCommandTest.java
@@ -111,7 +111,6 @@ public class AddCommandTest {
         @Override
         public void addReminder(Reminder reminder) {
             requireNonNull(reminder);
-
             remindersAdded.add(reminder);
         }
     }

--- a/src/test/java/seedu/address/logic/commands/reminder/AddCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/reminder/AddCommandTest.java
@@ -15,11 +15,10 @@ import java.util.Arrays;
 
 import org.junit.jupiter.api.Test;
 
-import javafx.collections.FXCollections;
-import javafx.collections.ObservableList;
 import seedu.address.logic.commands.CommandResult;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.ModelStub;
+import seedu.address.model.ModelStubWithSortedPersonList;
 import seedu.address.model.person.Person;
 import seedu.address.model.reminder.Reminder;
 import seedu.address.testutil.person.PersonBuilder;
@@ -98,19 +97,7 @@ public class AddCommandTest {
     }
 
     /**
-     * A Model stub that has a sortedPersonList containing {@code TypicalPerson#BOB}.
-     */
-    private class ModelStubWithSortedPersonList extends ModelStub {
-        @Override
-        public ObservableList<Person> getSortedPersonList() {
-            ObservableList<Person> sortedPersonList = FXCollections.observableArrayList();
-            sortedPersonList.add(BOB);
-            return sortedPersonList;
-        }
-    }
-
-    /**
-     * A Model stub that always accept the reminder associated with {@code TypicalPerson#BOB}.
+     * A Model stub that always accept the reminder being added.
      */
     private class ModelStubAcceptingReminderAdded extends ModelStubWithSortedPersonList {
         final ArrayList<Reminder> remindersAdded = new ArrayList<>();
@@ -124,14 +111,13 @@ public class AddCommandTest {
         @Override
         public void addReminder(Reminder reminder) {
             requireNonNull(reminder);
-            assert reminder.getPerson().equals(BOB);
 
             remindersAdded.add(reminder);
         }
     }
 
     /**
-     * A Model stub that contains a single reminder associated with {@code TypicalPerson#BOB}.
+     * A Model stub that contains a single reminder.
      */
     private class ModelStubWithReminder extends ModelStubWithSortedPersonList {
         private final Reminder reminder;

--- a/src/test/java/seedu/address/logic/commands/reminder/AddCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/reminder/AddCommandTest.java
@@ -1,0 +1,150 @@
+package seedu.address.logic.commands.reminder;
+
+import static java.util.Objects.requireNonNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static seedu.address.testutil.Assert.assertThrows;
+import static seedu.address.testutil.TypicalDates.TYPICAL_DATE_1;
+import static seedu.address.testutil.TypicalDates.TYPICAL_DATE_2;
+import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_ITEM;
+import static seedu.address.testutil.TypicalIndexes.INDEX_SECOND_ITEM;
+import static seedu.address.testutil.person.TypicalPersons.BOB;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+
+import org.junit.jupiter.api.Test;
+
+import javafx.collections.FXCollections;
+import javafx.collections.ObservableList;
+import seedu.address.logic.commands.CommandResult;
+import seedu.address.logic.commands.exceptions.CommandException;
+import seedu.address.model.ModelStub;
+import seedu.address.model.person.Person;
+import seedu.address.model.reminder.Reminder;
+import seedu.address.testutil.person.PersonBuilder;
+
+public class AddCommandTest {
+    private static final String MESSAGE = "message";
+
+    @Test
+    public void constructor_nullIndex_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> new AddCommand(null, MESSAGE, TYPICAL_DATE_1));
+    }
+
+    @Test
+    public void constructor_nullMessage_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> new AddCommand(INDEX_FIRST_ITEM, null,
+                TYPICAL_DATE_1));
+    }
+
+    @Test
+    public void constructor_nullScheduledDate_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> new AddCommand(INDEX_FIRST_ITEM, MESSAGE,
+                null));
+    }
+
+    @Test
+    public void execute_reminderAcceptedByModel_addSuccessful() throws Exception {
+        ModelStubAcceptingReminderAdded modelStub = new ModelStubAcceptingReminderAdded();
+        Person validPerson = new PersonBuilder(BOB).build();
+
+        Reminder reminder = new Reminder(validPerson, MESSAGE, TYPICAL_DATE_1);
+        CommandResult commandResult =
+                new AddCommand(INDEX_FIRST_ITEM, MESSAGE, TYPICAL_DATE_1).execute(modelStub);
+
+        assertEquals(String.format(AddCommand.MESSAGE_SUCCESS, reminder),
+                commandResult.getFeedbackToUser());
+        assertEquals(Arrays.asList(reminder), modelStub.remindersAdded);
+    }
+
+    @Test
+    public void execute_duplicateReminder_throwsCommandException() {
+        Person validPerson = new PersonBuilder(BOB).build();
+        Reminder reminder = new Reminder(validPerson, MESSAGE, TYPICAL_DATE_1);
+        ModelStub modelStub = new ModelStubWithReminder(reminder);
+
+        AddCommand addCommand = new AddCommand(INDEX_FIRST_ITEM, MESSAGE, TYPICAL_DATE_1);
+        assertThrows(CommandException.class, AddCommand.MESSAGE_DUPLICATE_REMINDER, () ->
+                addCommand.execute(modelStub));
+    }
+
+    @Test
+    public void equals() {
+        AddCommand addCallAliceReminderCommand = new AddCommand(INDEX_FIRST_ITEM, "Call Alice", TYPICAL_DATE_1);
+
+        // same object -> returns true
+        assertEquals(addCallAliceReminderCommand, addCallAliceReminderCommand);
+
+        // same values -> returns true
+        AddCommand addCallAliceReminderCommandCopy = new AddCommand(INDEX_FIRST_ITEM, "Call Alice", TYPICAL_DATE_1);
+        assertEquals(addCallAliceReminderCommand, addCallAliceReminderCommandCopy);
+
+        // different types -> returns false
+        assertNotEquals(addCallAliceReminderCommand, 1);
+
+        // null -> returns false
+        assertNotEquals(addCallAliceReminderCommand, null);
+
+        // different index -> returns false
+        assertNotEquals(addCallAliceReminderCommand, new AddCommand(INDEX_SECOND_ITEM, "Call Alice",
+                TYPICAL_DATE_1));
+
+        // different message -> returns false
+        assertNotEquals(addCallAliceReminderCommand, new AddCommand(INDEX_FIRST_ITEM, "Call Bob", TYPICAL_DATE_1));
+
+        // different date -> returns false
+        assertNotEquals(addCallAliceReminderCommand, new AddCommand(INDEX_FIRST_ITEM, "Call Alice", TYPICAL_DATE_2));
+    }
+
+    /**
+     * A Model stub that has a sortedPersonList containing {@code TypicalPerson#BOB}.
+     */
+    private class ModelStubWithSortedPersonList extends ModelStub {
+        @Override
+        public ObservableList<Person> getSortedPersonList() {
+            ObservableList<Person> sortedPersonList = FXCollections.observableArrayList();
+            sortedPersonList.add(BOB);
+            return sortedPersonList;
+        }
+    }
+
+    /**
+     * A Model stub that always accept the reminder associated with {@code TypicalPerson#BOB}.
+     */
+    private class ModelStubAcceptingReminderAdded extends ModelStubWithSortedPersonList {
+        final ArrayList<Reminder> remindersAdded = new ArrayList<>();
+
+        @Override
+        public boolean hasReminder(Reminder reminder) {
+            requireNonNull(reminder);
+            return remindersAdded.stream().anyMatch(reminder::equals);
+        }
+
+        @Override
+        public void addReminder(Reminder reminder) {
+            requireNonNull(reminder);
+            assert reminder.getPerson().equals(BOB);
+
+            remindersAdded.add(reminder);
+        }
+    }
+
+    /**
+     * A Model stub that contains a single reminder associated with {@code TypicalPerson#BOB}.
+     */
+    private class ModelStubWithReminder extends ModelStubWithSortedPersonList {
+        private final Reminder reminder;
+
+        ModelStubWithReminder(Reminder reminder) {
+            requireNonNull(reminder);
+            this.reminder = reminder;
+        }
+
+        @Override
+        public boolean hasReminder(Reminder reminder) {
+            requireNonNull(reminder);
+            return this.reminder.equals(reminder);
+        }
+    }
+}

--- a/src/test/java/seedu/address/logic/commands/reminder/DeleteCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/reminder/DeleteCommandTest.java
@@ -1,0 +1,66 @@
+package seedu.address.logic.commands.reminder;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static seedu.address.logic.commands.CommandTestUtil.assertCommandFailure;
+import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
+import static seedu.address.testutil.TypicalAddressBook.getTypicalAddressBook;
+import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_ITEM;
+import static seedu.address.testutil.TypicalIndexes.INDEX_SECOND_ITEM;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.commons.core.Messages;
+import seedu.address.commons.core.index.Index;
+import seedu.address.model.Model;
+import seedu.address.model.ModelManager;
+import seedu.address.model.UserPrefs;
+import seedu.address.model.reminder.Reminder;
+
+public class DeleteCommandTest {
+
+    private Model model = new ModelManager(getTypicalAddressBook(), new UserPrefs());
+
+    @Test
+    public void execute_validIndexUnfilteredList_success() {
+        Reminder reminderToDelete = model.getSortedReminderList().get(INDEX_FIRST_ITEM.getZeroBased());
+        DeleteCommand deleteCommand = new DeleteCommand(INDEX_FIRST_ITEM);
+
+        String expectedMessage = String.format(DeleteCommand.MESSAGE_DELETE_REMINDER_SUCCESS, reminderToDelete);
+
+        ModelManager expectedModel = new ModelManager(model.getAddressBook(), new UserPrefs());
+        expectedModel.deleteReminder(reminderToDelete);
+
+        assertCommandSuccess(deleteCommand, model, expectedMessage, expectedModel);
+    }
+
+    @Test
+    public void execute_invalidIndexUnfilteredList_throwsCommandException() {
+        Index outOfBoundIndex = Index.fromOneBased(model.getSortedReminderList().size() + 1);
+        DeleteCommand deleteCommand = new DeleteCommand(outOfBoundIndex);
+
+        assertCommandFailure(deleteCommand, model, Messages.MESSAGE_INVALID_REMINDER_DISPLAYED_INDEX);
+    }
+
+    @Test
+    public void equals() {
+        DeleteCommand deleteFirstCommand = new DeleteCommand(INDEX_FIRST_ITEM);
+        DeleteCommand deleteSecondCommand = new DeleteCommand(INDEX_SECOND_ITEM);
+
+        // same object -> returns true
+        assertEquals(deleteFirstCommand, deleteFirstCommand);
+
+        // same values -> returns true
+        DeleteCommand deleteFirstCommandCopy = new DeleteCommand(INDEX_FIRST_ITEM);
+        assertEquals(deleteFirstCommand, deleteFirstCommandCopy);
+
+        // different types -> returns false
+        assertNotEquals(deleteFirstCommand, 1);
+
+        // null -> returns false
+        assertNotEquals(deleteFirstCommand, null);
+
+        // different reminders -> returns false
+        assertNotEquals(deleteFirstCommand, deleteSecondCommand);
+    }
+}

--- a/src/test/java/seedu/address/logic/commands/reminder/DeleteCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/reminder/DeleteCommandTest.java
@@ -60,7 +60,7 @@ public class DeleteCommandTest {
         // null -> returns false
         assertNotEquals(deleteFirstCommand, null);
 
-        // different reminders -> returns false
+        // different indices -> returns false
         assertNotEquals(deleteFirstCommand, deleteSecondCommand);
     }
 }

--- a/src/test/java/seedu/address/logic/commands/reminder/ListCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/reminder/ListCommandTest.java
@@ -1,0 +1,39 @@
+package seedu.address.logic.commands.reminder;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
+import static seedu.address.testutil.TypicalAddressBook.getTypicalAddressBook;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import seedu.address.model.Model;
+import seedu.address.model.ModelManager;
+import seedu.address.model.UserPrefs;
+
+/**
+ * Contains integration tests (interaction with the Model) and unit tests for ListCommand.
+ */
+public class ListCommandTest {
+
+    private Model model;
+    private Model expectedModel;
+
+    @BeforeEach
+    public void setUp() {
+        model = new ModelManager(getTypicalAddressBook(), new UserPrefs());
+        expectedModel = new ModelManager(model.getAddressBook(), new UserPrefs());
+    }
+
+    @Test
+    public void execute_listIsNotFiltered_showsSameList() {
+        assertCommandSuccess(new ListCommand(), model, ListCommand.MESSAGE_SUCCESS, expectedModel);
+    }
+
+    @Test
+    public void equals() {
+        ListCommand listFirstCommand = new ListCommand();
+        ListCommand listSecondCommand = new ListCommand();
+        assertEquals(listFirstCommand, listSecondCommand);
+    }
+}

--- a/src/test/java/seedu/address/model/ModelStub.java
+++ b/src/test/java/seedu/address/model/ModelStub.java
@@ -1,0 +1,207 @@
+package seedu.address.model;
+
+import java.nio.file.Path;
+import java.util.Comparator;
+import java.util.function.Predicate;
+
+import javafx.collections.ObservableList;
+import seedu.address.commons.core.GuiSettings;
+import seedu.address.model.meeting.Meeting;
+import seedu.address.model.person.Person;
+import seedu.address.model.reminder.Reminder;
+import seedu.address.model.sale.Sale;
+import seedu.address.model.tag.Tag;
+
+/**
+ * A default model stub that have all of the methods failing.
+ */
+public class ModelStub implements Model {
+    @Override
+    public void setUserPrefs(ReadOnlyUserPrefs userPrefs) {
+        throw new AssertionError("This method should not be called.");
+    }
+
+    @Override
+    public ReadOnlyUserPrefs getUserPrefs() {
+        throw new AssertionError("This method should not be called.");
+    }
+
+    @Override
+    public GuiSettings getGuiSettings() {
+        throw new AssertionError("This method should not be called.");
+    }
+
+    @Override
+    public void setGuiSettings(GuiSettings guiSettings) {
+        throw new AssertionError("This method should not be called.");
+    }
+
+    @Override
+    public Path getAddressBookFilePath() {
+        throw new AssertionError("This method should not be called.");
+    }
+
+    @Override
+    public void setAddressBookFilePath(Path addressBookFilePath) {
+        throw new AssertionError("This method should not be called.");
+    }
+
+    @Override
+    public void addPerson(Person person) {
+        throw new AssertionError("This method should not be called.");
+    }
+
+    @Override
+    public void setAddressBook(ReadOnlyAddressBook newData) {
+        throw new AssertionError("This method should not be called.");
+    }
+
+    @Override
+    public ReadOnlyAddressBook getAddressBook() {
+        throw new AssertionError("This method should not be called.");
+    }
+
+    @Override
+    public boolean hasPerson(Person person) {
+        throw new AssertionError("This method should not be called.");
+    }
+
+    @Override
+    public boolean hasContactTag(Tag tag) {
+        throw new AssertionError("This method should not be called.");
+    }
+
+    @Override
+    public boolean hasSaleTag(Tag tag) {
+        throw new AssertionError("This method should not be called.");
+    }
+
+    @Override
+    public void addContactTag(Tag tag) {
+        throw new AssertionError("This method should not be called.");
+    }
+
+    @Override
+    public void editContactTag(Tag target, Tag editedTag) {
+        throw new AssertionError("This method should not be called.");
+    }
+
+    @Override
+    public void editSaleTag(Tag target, Tag editedTag) {
+        throw new AssertionError("This method should not be called.");
+    }
+
+    @Override
+    public void deleteContactTag(Tag target) {
+        throw new AssertionError("This method should not be called.");
+    }
+
+    @Override
+    public void deleteSaleTag(Tag target) {
+        throw new AssertionError("This method should not be called.");
+    }
+
+    @Override
+    public int findByContactTag(Tag target) {
+        throw new AssertionError("This method should not be called.");
+    }
+
+    @Override
+    public String findBySaleTag(Tag target) {
+        throw new AssertionError("This method should not be called.");
+    }
+
+    @Override
+    public String listTags() {
+        throw new AssertionError("This method should not be called.");
+    }
+
+    @Override
+    public ObservableList<Tag> getContactTagList() {
+        throw new AssertionError("This method should not be called.");
+    }
+
+    @Override
+    public ObservableList<Tag> getSaleTagList() {
+        throw new AssertionError("This method should not be called.");
+    }
+
+    @Override
+    public void deletePerson(Person target) {
+        throw new AssertionError("This method should not be called.");
+    }
+
+    @Override
+    public void setPerson(Person target, Person editedPerson) {
+        throw new AssertionError("This method should not be called.");
+    }
+
+    @Override
+    public ObservableList<Person> getFilteredPersonList() {
+        throw new AssertionError("This method should not be called.");
+    }
+
+    @Override
+    public void updateFilteredPersonList(Predicate<Person> predicate) {
+        throw new AssertionError("This method should not be called.");
+    }
+
+    @Override
+    public ObservableList<Person> getSortedPersonList() {
+        throw new AssertionError("This method should not be called.");
+    }
+
+    public void updateSortedPersonList(Comparator<Person> comparator) {
+        throw new AssertionError("This method should not be called.");
+    }
+
+    @Override
+    public ObservableList<Meeting> getSortedMeetingList() {
+        throw new AssertionError("This method should not be called.");
+    }
+
+    @Override
+    public boolean hasMeeting(Meeting meeting) {
+        throw new AssertionError("This method should not be called.");
+    }
+
+    @Override
+    public void deleteMeeting(Meeting target) {
+        throw new AssertionError("This method should not be called.");
+    }
+
+    @Override
+    public void addMeeting(Meeting meeting) {
+        throw new AssertionError("This method should not be called.");
+    }
+
+    @Override
+    public ObservableList<Reminder> getSortedReminderList() {
+        throw new AssertionError("This method should not be called.");
+    }
+
+    @Override
+    public boolean hasReminder(Reminder reminder) {
+        throw new AssertionError("This method should not be called.");
+    }
+
+    @Override
+    public void deleteReminder(Reminder target) {
+        throw new AssertionError("This method should not be called.");
+    }
+
+    @Override
+    public void addReminder(Reminder reminder) {
+        throw new AssertionError("This method should not be called.");
+    }
+
+    @Override
+    public void addSaleToPerson(Person person, Sale sale) {
+        throw new AssertionError("This method should not be called.");
+    }
+
+    @Override
+    public void removeSaleFromPerson(Person person, Sale sale) {
+        throw new AssertionError("This method should not be called.");
+    }
+}

--- a/src/test/java/seedu/address/model/ModelStubWithSortedPersonList.java
+++ b/src/test/java/seedu/address/model/ModelStubWithSortedPersonList.java
@@ -1,0 +1,22 @@
+package seedu.address.model;
+
+import static seedu.address.testutil.person.TypicalPersons.ALICE;
+import static seedu.address.testutil.person.TypicalPersons.BOB;
+
+import javafx.collections.FXCollections;
+import javafx.collections.ObservableList;
+import seedu.address.model.person.Person;
+
+/**
+ * A Model stub that has a sortedPersonList containing {@code TypicalPerson#BOB} at the first index (one-based), and
+ * {@code TypicalPerson#ALICE} at the second index.
+ */
+public class ModelStubWithSortedPersonList extends ModelStub {
+    @Override
+    public ObservableList<Person> getSortedPersonList() {
+        ObservableList<Person> sortedPersonList = FXCollections.observableArrayList();
+        sortedPersonList.add(BOB);
+        sortedPersonList.add(ALICE);
+        return sortedPersonList;
+    }
+}


### PR DESCRIPTION
Closes #110, #60 

- Enabled assertions in gradle (required for the coming week's tutorial)
- Added a visual indicator for overdue reminders
  - Reminders which are overdue will have its date label in red instead of white
- Updated the command feedback from running `reminder list` so that it will not display the entire reminder list in the chatbox.
- Extracted ModelStub from a private class in `seedu.address.commands.contact.AddCommandTest` to a public class in `seedu.address.model`
- Added tests cases for `commands.reminder` and `commands.meeting`

Demo:
![image](https://user-images.githubusercontent.com/24363622/96270900-cec41980-0ffe-11eb-80f7-ba864556850f.png)
