### PR TITLE
Refactor tag

### DIFF
--- a/docs/DeveloperGuide.md
+++ b/docs/DeveloperGuide.md
@@ -306,6 +306,21 @@ Priorities: High (must have) - `* * *`, Medium (nice to have) - `* *`, Low (unli
 
       Use case resumes at step 2.
 
+**Use case: Add a tag**
+
+**MSS**
+
+1.  User requests to add a new tag.
+2.  StonksBook adds the provided tag.
+
+    Use case ends.
+
+**Extensions**
+
+* 2a. The provided tag already exists in the tag list.
+
+    Use case ends.
+
 **Use case: View all tags**
 
 **MSS**

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -154,6 +154,21 @@ Examples:
 
 ### Tags
 
+#### Adding a tag: `tag add`
+
+Adds a new customised tag of the specified name to either the contact tags or sales tags. If there is an existing tag with this name, this command will not result in any change in state.
+
+Format: `tag add c/ (or s/) t/TAG`
+
+* Adds a tag with the specified `TAG` as the tag name to the contact tag list or sales tag list.
+* If this tag name already exists in the tag list, there will be no change in the program state.
+* The type of tag is specified by the empty prefix `c/` or `s/`, where `c/` adds the tag to the contact tag list, whilst `s/` adds the tag to the sales tag list.
+* The `TAG` field must be provided.
+
+Examples:
+
+* `tag add s/ t/electronics` adds the tag `electronics` to the sales tag list in StonksBook.
+
 #### Listing all tags: `tag list`
 
 Displays a list of all tags created so far.

--- a/src/main/java/seedu/address/commons/core/Messages.java
+++ b/src/main/java/seedu/address/commons/core/Messages.java
@@ -19,5 +19,7 @@ public class Messages {
     public static final String MESSAGE_INVALID_TAG_DISPLAYED_INDEX = "The tag index provided is invalid";
     public static final String MESSAGE_INVALID_MEETING_DISPLAYED_INDEX = "The meeting index provided is invalid";
     public static final String MESSAGE_INVALID_SALE_DISPLAYED_INDEX = "The sale index provided is invalid";
+    public static final String MESSAGE_SALE_TAGS_NOT_FOUND = "The provided sales tag(s) do not exist yet";
+    public static final String MESSAGE_CONTACT_TAGS_NOT_FOUND = "The provided contact tag(s) do not exist yet";
 
 }

--- a/src/main/java/seedu/address/logic/commands/contact/AddCommand.java
+++ b/src/main/java/seedu/address/logic/commands/contact/AddCommand.java
@@ -8,6 +8,7 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_CONTACT_PHONE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_CONTACT_REMARK;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
 
+import seedu.address.commons.core.Messages;
 import seedu.address.logic.commands.Command;
 import seedu.address.logic.commands.CommandResult;
 import seedu.address.logic.commands.exceptions.CommandException;
@@ -53,6 +54,10 @@ public class AddCommand extends Command {
     @Override
     public CommandResult execute(Model model) throws CommandException {
         requireNonNull(model);
+
+        if (!model.contactTagsExist(toAdd)) {
+            throw new CommandException(Messages.MESSAGE_CONTACT_TAGS_NOT_FOUND);
+        }
 
         if (model.hasPerson(toAdd)) {
             throw new CommandException(MESSAGE_DUPLICATE_PERSON);

--- a/src/main/java/seedu/address/logic/commands/contact/EditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/contact/EditCommand.java
@@ -83,6 +83,10 @@ public class EditCommand extends Command {
         Person personToEdit = lastShownList.get(index.getZeroBased());
         Person editedPerson = createEditedPerson(personToEdit, editPersonDescriptor);
 
+        if (!model.contactTagsExist(editedPerson)) {
+            throw new CommandException(Messages.MESSAGE_CONTACT_TAGS_NOT_FOUND);
+        }
+
         if (!personToEdit.isSamePerson(editedPerson) && model.hasPerson(editedPerson)) {
             throw new CommandException(MESSAGE_DUPLICATE_PERSON);
         }

--- a/src/main/java/seedu/address/logic/commands/sale/AddCommand.java
+++ b/src/main/java/seedu/address/logic/commands/sale/AddCommand.java
@@ -31,9 +31,10 @@ public class AddCommand extends Command {
         + "Parameters: "
         + PREFIX_SALE_CONTACT_INDEX + "CONTACT_INDEX (must be a positive integer) "
         + PREFIX_SALE_NAME + "ITEM_NAME "
-        + PREFIX_SALE_DATE + "DATETIME_OF_PURCHASE"
+        + PREFIX_SALE_DATE + "DATETIME_OF_PURCHASE "
         + PREFIX_SALE_UNIT_PRICE + "UNIT_PRICE "
-        + PREFIX_SALE_QUANTITY + "QUANTITY\n"
+        + PREFIX_SALE_QUANTITY + "QUANTITY "
+        + "[" + PREFIX_TAG + "TAG]...\n"
         + "Example: " + COMMAND_WORD + " "
         + PREFIX_SALE_CONTACT_INDEX + "2 "
         + PREFIX_SALE_NAME + "Apple "
@@ -68,6 +69,10 @@ public class AddCommand extends Command {
 
         if (index.getZeroBased() >= lastShownList.size()) {
             throw new CommandException(Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
+        }
+
+        if (!model.saleTagsExist(toAdd)) {
+            throw new CommandException(Messages.MESSAGE_SALE_TAGS_NOT_FOUND);
         }
 
         Person personToEdit = lastShownList.get(index.getZeroBased());

--- a/src/main/java/seedu/address/logic/commands/sale/AddCommand.java
+++ b/src/main/java/seedu/address/logic/commands/sale/AddCommand.java
@@ -34,7 +34,7 @@ public class AddCommand extends Command {
         + PREFIX_SALE_DATE + "DATETIME_OF_PURCHASE "
         + PREFIX_SALE_UNIT_PRICE + "UNIT_PRICE "
         + PREFIX_SALE_QUANTITY + "QUANTITY "
-        + "[" + PREFIX_TAG + "TAG]...\n"
+        + PREFIX_TAG + "TAG...\n"
         + "Example: " + COMMAND_WORD + " "
         + PREFIX_SALE_CONTACT_INDEX + "2 "
         + PREFIX_SALE_NAME + "Apple "

--- a/src/main/java/seedu/address/logic/commands/tag/AddCommand.java
+++ b/src/main/java/seedu/address/logic/commands/tag/AddCommand.java
@@ -1,0 +1,71 @@
+package seedu.address.logic.commands.tag;
+
+
+import static java.util.Objects.requireNonNull;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_SALE;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
+
+import seedu.address.logic.commands.Command;
+import seedu.address.logic.commands.CommandResult;
+import seedu.address.logic.commands.exceptions.CommandException;
+import seedu.address.model.Model;
+import seedu.address.model.tag.Tag;
+
+
+/**
+ * Adds a tag to the StonksBook.
+ */
+public class AddCommand extends Command {
+    public static final String COMMAND_WORD = "tag add";
+
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Adds a tag (for contacts or for sales) to the StonksBook. "
+            + "Parameters: "
+            + "c/ (or s/) "
+            + PREFIX_TAG + "TAG\n"
+            + "Example: " + COMMAND_WORD + " "
+            + PREFIX_SALE + " "
+            + PREFIX_TAG + "fruits";
+
+    public static final String MESSAGE_CONTACT_SUCCESS = "New contact tag added: %1$s";
+    public static final String MESSAGE_SALES_SUCCESS = "New sales tag added: %1$s";
+    public static final String MESSAGE_DUPLICATE_CONTACT_TAG = "This contact tag already exists in StonksBook";
+    public static final String MESSAGE_DUPLICATE_SALES_TAG = "This sales tag already exists in StonksBook";
+
+    private final Tag toAdd;
+    private final boolean isContact;
+
+    /**
+     * Creates an AddCommand to add the specified {@code Tag}
+     */
+    public AddCommand(Tag tag, boolean isContact) {
+        requireNonNull(tag);
+        toAdd = tag;
+        this.isContact = isContact;
+    }
+
+    @Override
+    public CommandResult execute(Model model) throws CommandException {
+        requireNonNull(model);
+
+        if (isContact) {
+            if (model.hasContactTag(toAdd)) {
+                throw new CommandException(MESSAGE_DUPLICATE_CONTACT_TAG);
+            }
+            model.addContactTag(toAdd);
+            return new CommandResult(String.format(MESSAGE_CONTACT_SUCCESS, toAdd));
+        } else {
+            if (model.hasSaleTag(toAdd)) {
+                throw new CommandException(MESSAGE_DUPLICATE_SALES_TAG);
+            }
+            model.addSaleTag(toAdd);
+            return new CommandResult(String.format(MESSAGE_SALES_SUCCESS, toAdd));
+        }
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return other == this // short circuit if same object
+                || (other instanceof seedu.address.logic.commands.tag.AddCommand // instanceof handles nulls
+                && toAdd.equals(((seedu.address.logic.commands.tag.AddCommand) other).toAdd));
+    }
+}

--- a/src/main/java/seedu/address/logic/commands/tag/AddCommand.java
+++ b/src/main/java/seedu/address/logic/commands/tag/AddCommand.java
@@ -31,6 +31,8 @@ public class AddCommand extends Command {
     public static final String MESSAGE_SALES_SUCCESS = "New sales tag added: %1$s";
     public static final String MESSAGE_DUPLICATE_CONTACT_TAG = "This contact tag already exists in StonksBook";
     public static final String MESSAGE_DUPLICATE_SALES_TAG = "This sales tag already exists in StonksBook";
+    public static final String MESSAGE_CONFLICT_TYPES =
+            "Invalid tag type provided! Please use either c/ or s/, but not both.\n";
 
     private final Tag toAdd;
     private final boolean isContact;
@@ -66,7 +68,7 @@ public class AddCommand extends Command {
     @Override
     public boolean equals(Object other) {
         return other == this // short circuit if same object
-                || (other instanceof seedu.address.logic.commands.tag.AddCommand // instanceof handles nulls
-                && toAdd.equals(((seedu.address.logic.commands.tag.AddCommand) other).toAdd));
+                || (other instanceof AddCommand // instanceof handles nulls
+                && toAdd.equals(((AddCommand) other).toAdd));
     }
 }

--- a/src/main/java/seedu/address/logic/commands/tag/AddCommand.java
+++ b/src/main/java/seedu/address/logic/commands/tag/AddCommand.java
@@ -18,7 +18,8 @@ import seedu.address.model.tag.Tag;
 public class AddCommand extends Command {
     public static final String COMMAND_WORD = "tag add";
 
-    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Adds a tag (for contacts or for sales) to the StonksBook. "
+    public static final String MESSAGE_USAGE =
+            COMMAND_WORD + ": Adds a tag (for contacts or for sales) to the StonksBook. "
             + "Parameters: "
             + "c/ (or s/) "
             + PREFIX_TAG + "TAG\n"

--- a/src/main/java/seedu/address/logic/parser/CliSyntax.java
+++ b/src/main/java/seedu/address/logic/parser/CliSyntax.java
@@ -26,4 +26,5 @@ public class CliSyntax {
     public static final Prefix PREFIX_MESSAGE = new Prefix("m/");
     public static final Prefix PREFIX_DATETIME = new Prefix("d/");
     public static final Prefix PREFIX_DURATION = new Prefix("du/");
+    public static final Prefix PREFIX_SALE = new Prefix("s/");
 }

--- a/src/main/java/seedu/address/logic/parser/sale/AddCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/sale/AddCommandParser.java
@@ -41,7 +41,7 @@ public class AddCommandParser implements Parser<AddCommand> {
                 PREFIX_SALE_DATE, PREFIX_SALE_QUANTITY, PREFIX_TAG, PREFIX_SALE_UNIT_PRICE);
 
         if (!arePrefixesPresent(argMultimap, PREFIX_SALE_CONTACT_INDEX, PREFIX_SALE_NAME, PREFIX_SALE_DATE,
-                PREFIX_SALE_QUANTITY, PREFIX_SALE_UNIT_PRICE)
+                PREFIX_SALE_QUANTITY, PREFIX_SALE_UNIT_PRICE, PREFIX_TAG)
             || !argMultimap.getPreamble().isEmpty()) {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddCommand.MESSAGE_USAGE));
         }

--- a/src/main/java/seedu/address/logic/parser/tag/AddCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/tag/AddCommandParser.java
@@ -1,5 +1,12 @@
 package seedu.address.logic.parser.tag;
 
+import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_CONTACT;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_SALE;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
+
+import java.util.stream.Stream;
+
 import seedu.address.logic.commands.tag.AddCommand;
 import seedu.address.logic.parser.ArgumentMultimap;
 import seedu.address.logic.parser.ArgumentTokenizer;
@@ -8,13 +15,6 @@ import seedu.address.logic.parser.Prefix;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.tag.Tag;
 
-import java.util.stream.Stream;
-
-import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_CONTACT;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_SALE;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
-
 public class AddCommandParser implements Parser<AddCommand> {
 
     @Override
@@ -22,6 +22,7 @@ public class AddCommandParser implements Parser<AddCommand> {
         ArgumentMultimap argMultimap =
                 ArgumentTokenizer.tokenize(userInput, PREFIX_SALE, PREFIX_CONTACT, PREFIX_TAG);
 
+        System.out.println(userInput);
         if (!arePrefixesPresent(argMultimap, PREFIX_TAG) || !argMultimap.getPreamble().isEmpty()) {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT,
                     seedu.address.logic.commands.tag.AddCommand.MESSAGE_USAGE));
@@ -41,7 +42,7 @@ public class AddCommandParser implements Parser<AddCommand> {
         } else if (!argMultimap.getValue(PREFIX_CONTACT).isEmpty()) {
             return new AddCommand(tag, true);
         } else {
-            throw new ParseException(AddCommand.MESSAGE_USAGE);
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddCommand.MESSAGE_USAGE));
         }
     }
 

--- a/src/main/java/seedu/address/logic/parser/tag/AddCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/tag/AddCommandParser.java
@@ -4,14 +4,12 @@ import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT
 import static seedu.address.logic.parser.CliSyntax.PREFIX_CONTACT;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_SALE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
-
-import java.util.stream.Stream;
+import static seedu.address.logic.parser.ParserUtil.arePrefixesPresent;
 
 import seedu.address.logic.commands.tag.AddCommand;
 import seedu.address.logic.parser.ArgumentMultimap;
 import seedu.address.logic.parser.ArgumentTokenizer;
 import seedu.address.logic.parser.Parser;
-import seedu.address.logic.parser.Prefix;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.tag.Tag;
 
@@ -22,35 +20,28 @@ public class AddCommandParser implements Parser<AddCommand> {
         ArgumentMultimap argMultimap =
                 ArgumentTokenizer.tokenize(userInput, PREFIX_SALE, PREFIX_CONTACT, PREFIX_TAG);
 
-        System.out.println(userInput);
         if (!arePrefixesPresent(argMultimap, PREFIX_TAG) || !argMultimap.getPreamble().isEmpty()) {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT,
-                    seedu.address.logic.commands.tag.AddCommand.MESSAGE_USAGE));
+                    AddCommand.MESSAGE_USAGE));
         }
 
         String tagName = argMultimap.getValue(PREFIX_TAG).get();
 
         if (tagName.isEmpty()) {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT,
-                    seedu.address.logic.commands.tag.AddCommand.MESSAGE_USAGE));
+                    AddCommand.MESSAGE_USAGE));
         }
 
         Tag tag = new Tag(tagName);
 
-        if (!argMultimap.getValue(PREFIX_SALE).isEmpty()) {
+        if (!argMultimap.getValue(PREFIX_CONTACT).isEmpty() && !argMultimap.getValue(PREFIX_SALE).isEmpty()) {
+            throw new ParseException(AddCommand.MESSAGE_CONFLICT_TYPES);
+        } else if (!argMultimap.getValue(PREFIX_SALE).isEmpty()) {
             return new AddCommand(tag, false);
         } else if (!argMultimap.getValue(PREFIX_CONTACT).isEmpty()) {
             return new AddCommand(tag, true);
         } else {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddCommand.MESSAGE_USAGE));
         }
-    }
-
-    /**
-     * Returns true if none of the prefixes contains empty {@code Optional} values in the given
-     * {@code ArgumentMultimap}.
-     */
-    private static boolean arePrefixesPresent(ArgumentMultimap argumentMultimap, Prefix... prefixes) {
-        return Stream.of(prefixes).allMatch(prefix -> argumentMultimap.getValue(prefix).isPresent());
     }
 }

--- a/src/main/java/seedu/address/logic/parser/tag/AddCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/tag/AddCommandParser.java
@@ -1,0 +1,55 @@
+package seedu.address.logic.parser.tag;
+
+import seedu.address.logic.commands.tag.AddCommand;
+import seedu.address.logic.parser.ArgumentMultimap;
+import seedu.address.logic.parser.ArgumentTokenizer;
+import seedu.address.logic.parser.Parser;
+import seedu.address.logic.parser.Prefix;
+import seedu.address.logic.parser.exceptions.ParseException;
+import seedu.address.model.tag.Tag;
+
+import java.util.stream.Stream;
+
+import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_CONTACT;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_SALE;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
+
+public class AddCommandParser implements Parser<AddCommand> {
+
+    @Override
+    public AddCommand parse(String userInput) throws ParseException {
+        ArgumentMultimap argMultimap =
+                ArgumentTokenizer.tokenize(userInput, PREFIX_SALE, PREFIX_CONTACT, PREFIX_TAG);
+
+        if (!arePrefixesPresent(argMultimap, PREFIX_TAG) || !argMultimap.getPreamble().isEmpty()) {
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+                    seedu.address.logic.commands.tag.AddCommand.MESSAGE_USAGE));
+        }
+
+        String tagName = argMultimap.getValue(PREFIX_TAG).get();
+
+        if (tagName.isEmpty()) {
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+                    seedu.address.logic.commands.tag.AddCommand.MESSAGE_USAGE));
+        }
+
+        Tag tag = new Tag(tagName);
+
+        if (!argMultimap.getValue(PREFIX_SALE).isEmpty()) {
+            return new AddCommand(tag, false);
+        } else if (!argMultimap.getValue(PREFIX_CONTACT).isEmpty()) {
+            return new AddCommand(tag, true);
+        } else {
+            throw new ParseException(AddCommand.MESSAGE_USAGE);
+        }
+    }
+
+    /**
+     * Returns true if none of the prefixes contains empty {@code Optional} values in the given
+     * {@code ArgumentMultimap}.
+     */
+    private static boolean arePrefixesPresent(ArgumentMultimap argumentMultimap, Prefix... prefixes) {
+        return Stream.of(prefixes).allMatch(prefix -> argumentMultimap.getValue(prefix).isPresent());
+    }
+}

--- a/src/main/java/seedu/address/logic/parser/tag/TagCommandsParser.java
+++ b/src/main/java/seedu/address/logic/parser/tag/TagCommandsParser.java
@@ -5,6 +5,7 @@ import java.util.List;
 
 import seedu.address.logic.commands.Command;
 import seedu.address.logic.commands.UnknownCommand;
+import seedu.address.logic.commands.tag.AddCommand;
 import seedu.address.logic.commands.tag.DeleteCommand;
 import seedu.address.logic.commands.tag.EditCommand;
 import seedu.address.logic.commands.tag.FindCommand;
@@ -24,6 +25,8 @@ public class TagCommandsParser implements GroupCommandsParser {
     @Override
     public Command parse(String commandWord, String arguments) throws ParseException {
         switch (commandWord) {
+        case AddCommand.COMMAND_WORD:
+            return new AddCommandParser().parse(arguments);
         case ListCommand.COMMAND_WORD:
             return new ListCommand();
         case DeleteCommand.COMMAND_WORD:

--- a/src/main/java/seedu/address/model/AddressBook.java
+++ b/src/main/java/seedu/address/model/AddressBook.java
@@ -292,7 +292,7 @@ public class AddressBook implements ReadOnlyAddressBook {
     }
 
     /**
-     * Returns if all the tags of the provided {@code sale} item exist in StonksBook.
+     * Returns true if all the tags of the provided {@code sale} item exist in StonksBook.
      */
     public boolean saleTagsExist(Sale sale) {
         for (Tag t : sale.getTags()) {
@@ -304,7 +304,7 @@ public class AddressBook implements ReadOnlyAddressBook {
     }
 
     /**
-     * Returns if all the tags of the provided {@code sale} item exist in StonksBook.
+     * Returns true if all the tags of the provided {@code sale} item exist in StonksBook.
      */
     public boolean contactTagsExist(Person person) {
         for (Tag t : person.getTags()) {

--- a/src/main/java/seedu/address/model/AddressBook.java
+++ b/src/main/java/seedu/address/model/AddressBook.java
@@ -146,11 +146,6 @@ public class AddressBook implements ReadOnlyAddressBook {
         for (Tag t : editedPerson.getTags()) {
             contactTags.add(t);
         }
-        for (Tag t : target.getTags()) {
-            if (persons.hasZeroOccurrences(t)) {
-                contactTags.remove(t);
-            }
-        }
     }
 
     /**
@@ -411,11 +406,6 @@ public class AddressBook implements ReadOnlyAddressBook {
                         toRemove.remove(t);
                     }
                 }
-            }
-        }
-        if (!toRemove.isEmpty()) {
-            for (Tag t : toRemove) {
-                saleTags.remove(t);
             }
         }
     }

--- a/src/main/java/seedu/address/model/AddressBook.java
+++ b/src/main/java/seedu/address/model/AddressBook.java
@@ -297,6 +297,30 @@ public class AddressBook implements ReadOnlyAddressBook {
     }
 
     /**
+     * Returns if all the tags of the provided {@code sale} item exist in StonksBook.
+     */
+    public boolean saleTagsExist(Sale sale) {
+        for (Tag t : sale.getTags()) {
+            if (!saleTags.contains(t)) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    /**
+     * Returns if all the tags of the provided {@code sale} item exist in StonksBook.
+     */
+    public boolean contactTagsExist(Person person) {
+        for (Tag t : person.getTags()) {
+            if (!contactTags.contains(t)) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    /**
      * Re-order all the existing tags in StonksBook.
      */
     public void sortTags() {

--- a/src/main/java/seedu/address/model/Model.java
+++ b/src/main/java/seedu/address/model/Model.java
@@ -84,10 +84,16 @@ public interface Model {
     boolean hasSaleTag(Tag tag);
 
     /**
-     * Adds the given tag.
+     * Adds the given {@code tag} to the contact tag list.
      * {@code tag} must not already exist in StonksBook.
      */
     void addContactTag(Tag tag);
+
+    /**
+     * Adds the given {@code tag} to the sales tag list.
+     * {@code tag} must not already exist in StonksBook.
+     */
+    void addSaleTag(Tag tag);
 
     /**
      * Replaces the given {@code tag} with {@code editedTag}.
@@ -129,6 +135,16 @@ public interface Model {
      * Lists all existing tags.
      */
     String listTags();
+
+    /**
+     * Returns if the {@code sale} item's tags are present in StonksBook.
+     */
+    boolean saleTagsExist(Sale sale);
+
+    /**
+     * Returns if the {@code person}'s tags are present in StonksBook.
+     */
+    boolean contactTagsExist(Person person);
 
     /**
      * Returns an unmodifiable view of the contact tag list.

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -130,6 +130,11 @@ public class ModelManager implements Model {
     }
 
     @Override
+    public void addSaleTag(Tag tag) {
+        addressBook.addSaleTag(tag);
+    }
+
+    @Override
     public void editContactTag(Tag target, Tag editedTag) {
         requireAllNonNull(target, editedTag);
 
@@ -273,6 +278,16 @@ public class ModelManager implements Model {
     @Override
     public String listTags() {
         return addressBook.listTags();
+    }
+
+    @Override
+    public boolean saleTagsExist(Sale sale) {
+        return addressBook.saleTagsExist(sale);
+    }
+
+    @Override
+    public boolean contactTagsExist(Person person) {
+        return addressBook.contactTagsExist(person);
     }
 
     //=========== Reminder List Accessors =============================================================

--- a/src/main/java/seedu/address/storage/JsonSerializableAddressBook.java
+++ b/src/main/java/seedu/address/storage/JsonSerializableAddressBook.java
@@ -14,6 +14,7 @@ import seedu.address.model.ReadOnlyAddressBook;
 import seedu.address.model.meeting.Meeting;
 import seedu.address.model.person.Person;
 import seedu.address.model.reminder.Reminder;
+import seedu.address.model.tag.Tag;
 
 /**
  * An Immutable AddressBook that is serializable to JSON format.
@@ -76,6 +77,17 @@ class JsonSerializableAddressBook {
             }
             addressBook.addPerson(person);
         }
+
+        for (JsonAdaptedTag jsonAdaptedTag : saleTags) {
+            Tag tag = jsonAdaptedTag.toModelType();
+            addressBook.addSaleTag(tag);
+        }
+
+        for (JsonAdaptedTag jsonAdaptedTag : contactTags) {
+            Tag tag = jsonAdaptedTag.toModelType();
+            addressBook.addContactTag(tag);
+        }
+
         addressBook.sortTags();
 
         for (JsonAdaptedMeeting jsonAdaptedMeeting : meetings) {

--- a/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
+++ b/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
@@ -111,6 +111,7 @@ public class CommandTestUtil {
     public static final String QUANTITY_DESC_APPLE = " " + PREFIX_SALE_QUANTITY + VALID_QUANTITY_APPLE;
     public static final String UNIT_PRICE_DESC_APPLE =
             " " + PREFIX_SALE_UNIT_PRICE + VALID_UNIT_PRICE_DOLLARS_APPLE + "." + VALID_UNIT_PRICE_CENTS_APPLE;
+    public static final String SALE_TAG_FRUITS = " " + PREFIX_TAG + "fruits";
 
     public static final String VALID_SALE_TAG = " " + PREFIX_TAG + VALID_SALE_TAG_FRUITS;
 

--- a/src/test/java/seedu/address/logic/commands/contact/AddCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/contact/AddCommandTest.java
@@ -150,6 +150,11 @@ public class AddCommandTest {
         }
 
         @Override
+        public void addSaleTag(Tag tag) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
         public void editContactTag(Tag target, Tag editedTag) {
             throw new AssertionError("This method should not be called.");
         }
@@ -182,6 +187,16 @@ public class AddCommandTest {
         @Override
         public String listTags() {
             throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public boolean saleTagsExist(Sale sale) {
+            return true;
+        }
+
+        @Override
+        public boolean contactTagsExist(Person person) {
+            return true;
         }
 
         @Override

--- a/src/test/java/seedu/address/logic/commands/contact/EditCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/contact/EditCommandTest.java
@@ -25,6 +25,7 @@ import seedu.address.model.Model;
 import seedu.address.model.ModelManager;
 import seedu.address.model.UserPrefs;
 import seedu.address.model.person.Person;
+import seedu.address.model.tag.Tag;
 import seedu.address.testutil.person.EditPersonDescriptorBuilder;
 import seedu.address.testutil.person.PersonBuilder;
 
@@ -51,6 +52,7 @@ public class EditCommandTest {
 
     @Test
     public void execute_someFieldsSpecifiedUnfilteredList_success() {
+        model.addContactTag(new Tag(VALID_TAG_HUSBAND));
         Index indexLastPerson = Index.fromOneBased(model.getSortedPersonList().size());
         Person lastPerson = model.getSortedPersonList().get(indexLastPerson.getZeroBased());
 

--- a/src/test/java/seedu/address/logic/commands/sale/AddCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/sale/AddCommandTest.java
@@ -20,6 +20,7 @@ import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.ModelManager;
 import seedu.address.model.person.Person;
 import seedu.address.model.sale.UniqueSaleList;
+import seedu.address.testutil.TypicalSaleTags;
 import seedu.address.testutil.person.PersonBuilder;
 
 public class AddCommandTest {
@@ -46,6 +47,7 @@ public class AddCommandTest {
         Person validPerson = new PersonBuilder(BOB).withSales(APPLE).build();
         ModelManager model = new ModelManager();
         model.addPerson(validPerson);
+        model.addSaleTag(TypicalSaleTags.SPORTS);
 
         CommandResult commandResult = new AddCommand(INDEX_FIRST_ITEM, BALL).execute(model);
 

--- a/src/test/java/seedu/address/logic/commands/tag/AddCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/tag/AddCommandTest.java
@@ -1,0 +1,71 @@
+package seedu.address.logic.commands.tag;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
+import static seedu.address.testutil.TypicalAddressBook.getTypicalAddressBook;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.model.AddressBook;
+import seedu.address.model.Model;
+import seedu.address.model.ModelManager;
+import seedu.address.model.UserPrefs;
+import seedu.address.model.tag.Tag;
+
+class AddCommandTest {
+    private static final String BANANAS = "bananas";
+    private static final String MINIONS = "minions";
+
+    private Model model = new ModelManager(getTypicalAddressBook(), new UserPrefs());
+
+    @Test
+    public void execute_validContactTag_success() {
+        Tag tagToAdd = new Tag(MINIONS);
+        AddCommand addCommand = new AddCommand(tagToAdd, true);
+
+        String expectedMessage = String.format(AddCommand.MESSAGE_CONTACT_SUCCESS, tagToAdd);
+
+        Model expectedModel = new ModelManager(new AddressBook(model.getAddressBook()), new UserPrefs());
+        expectedModel.addContactTag(tagToAdd);
+
+        assertCommandSuccess(addCommand, model, expectedMessage, expectedModel);
+    }
+
+    @Test
+    public void execute_validSaleTag_success() {
+        Tag tagToAdd = new Tag(BANANAS);
+        AddCommand addCommand = new AddCommand(tagToAdd, false);
+
+        String expectedMessage = String.format(AddCommand.MESSAGE_SALES_SUCCESS, tagToAdd);
+
+        Model expectedModel = new ModelManager(new AddressBook(model.getAddressBook()), new UserPrefs());
+        expectedModel.addSaleTag(tagToAdd);
+
+        assertCommandSuccess(addCommand, model, expectedMessage, expectedModel);
+    }
+
+    @Test
+    public void equals() {
+        Tag bananas = new Tag(BANANAS);
+        Tag minions = new Tag(MINIONS);
+        AddCommand addContactTagCommand = new AddCommand(minions, true);
+        AddCommand addSaleTagCommand = new AddCommand(bananas, false);
+
+        // same object -> returns true
+        assertTrue(addContactTagCommand.equals(addContactTagCommand));
+
+        // same values -> returns true
+        AddCommand addContactTagCommandCopy = new AddCommand(minions, true);
+        assertTrue(addContactTagCommand.equals(addContactTagCommandCopy));
+
+        // different types -> returns false
+        assertFalse(addContactTagCommand.equals(1));
+
+        // null -> returns false
+        assertFalse(addContactTagCommand.equals(null));
+
+        // different tags -> returns false
+        assertFalse(addContactTagCommand.equals(addSaleTagCommand));
+    }
+}

--- a/src/test/java/seedu/address/logic/parser/sale/AddCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/sale/AddCommandParserTest.java
@@ -11,6 +11,7 @@ import static seedu.address.logic.commands.CommandTestUtil.ITEM_NAME_DESC_APPLE;
 import static seedu.address.logic.commands.CommandTestUtil.PREAMBLE_NON_EMPTY;
 import static seedu.address.logic.commands.CommandTestUtil.QUANTITY_DESC_APPLE;
 import static seedu.address.logic.commands.CommandTestUtil.SALE_DATE_DESC_APPLE;
+import static seedu.address.logic.commands.CommandTestUtil.SALE_TAG_FRUITS;
 import static seedu.address.logic.commands.CommandTestUtil.UNIT_PRICE_DESC_APPLE;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_DATE_APPLE;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_ITEM_NAME_APPLE;
@@ -83,23 +84,23 @@ public class AddCommandParserTest {
     public void parse_invalidValue_failure() {
         // invalid item name
         assertParseFailure(parser, CONTACT_INDEX_SECOND + INVALID_ITEM_NAME + SALE_DATE_DESC_APPLE
-                + QUANTITY_DESC_APPLE + UNIT_PRICE_DESC_APPLE, ItemName.MESSAGE_CONSTRAINTS);
+                + QUANTITY_DESC_APPLE + UNIT_PRICE_DESC_APPLE + SALE_TAG_FRUITS, ItemName.MESSAGE_CONSTRAINTS);
 
         // invalid date
         assertParseFailure(parser, CONTACT_INDEX_SECOND + ITEM_NAME_DESC_APPLE + INVALID_SALE_DATE
-                + QUANTITY_DESC_APPLE + UNIT_PRICE_DESC_APPLE, MESSAGE_INVALID_DATETIME);
+                + QUANTITY_DESC_APPLE + UNIT_PRICE_DESC_APPLE + SALE_TAG_FRUITS, MESSAGE_INVALID_DATETIME);
 
         // invalid quantity
         assertParseFailure(parser, CONTACT_INDEX_SECOND + ITEM_NAME_DESC_APPLE + SALE_DATE_DESC_APPLE
-                + INVALID_QUANTITY + UNIT_PRICE_DESC_APPLE, Quantity.MESSAGE_CONSTRAINTS);
+                + INVALID_QUANTITY + UNIT_PRICE_DESC_APPLE + SALE_TAG_FRUITS, Quantity.MESSAGE_CONSTRAINTS);
 
         // invalid unit price
         assertParseFailure(parser, CONTACT_INDEX_SECOND + ITEM_NAME_DESC_APPLE + SALE_DATE_DESC_APPLE
-                + QUANTITY_DESC_APPLE + INVALID_UNIT_PRICE, UnitPrice.MESSAGE_CONSTRAINTS);
+                + QUANTITY_DESC_APPLE + INVALID_UNIT_PRICE + SALE_TAG_FRUITS, UnitPrice.MESSAGE_CONSTRAINTS);
 
         // non-empty preamble
         assertParseFailure(parser, PREAMBLE_NON_EMPTY + CONTACT_INDEX_SECOND + ITEM_NAME_DESC_APPLE
-                        + SALE_DATE_DESC_APPLE + QUANTITY_DESC_APPLE + UNIT_PRICE_DESC_APPLE,
+                        + SALE_DATE_DESC_APPLE + QUANTITY_DESC_APPLE + UNIT_PRICE_DESC_APPLE + SALE_TAG_FRUITS,
                 String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddCommand.MESSAGE_USAGE));
     }
 }

--- a/src/test/java/seedu/address/logic/parser/tag/AddCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/tag/AddCommandParserTest.java
@@ -1,0 +1,39 @@
+package seedu.address.logic.parser.tag;
+
+import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_CONTACT;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_SALE;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
+import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
+import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.logic.commands.tag.AddCommand;
+import seedu.address.model.tag.Tag;
+
+class AddCommandParserTest {
+
+    private static final String BANANAS = "bananas";
+    private static final String MINIONS = "minions";
+
+    private AddCommandParser parser = new AddCommandParser();
+
+    @Test
+    public void parse_validInput_returnsAddCommand() {
+        Tag contactTagToAdd = new Tag(MINIONS);
+        Tag salesTagToAdd = new Tag(BANANAS);
+        // Parses input to add a contact tag
+        assertParseSuccess(parser, String.format(" %s %s%s", PREFIX_CONTACT, PREFIX_TAG, MINIONS),
+                new AddCommand(contactTagToAdd, true));
+        // Parses input to add a sales tag
+        assertParseSuccess(parser, String.format(" %s %s%s", PREFIX_SALE, PREFIX_TAG, BANANAS),
+                new AddCommand(salesTagToAdd, false));
+    }
+
+    @Test
+    public void parse_invalidInput_throwsParseException() {
+        assertParseFailure(parser, String.format(" %s%s", PREFIX_TAG, MINIONS),
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddCommand.MESSAGE_USAGE));
+    }
+}

--- a/src/test/java/seedu/address/logic/parser/tag/EditCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/tag/EditCommandParserTest.java
@@ -4,15 +4,11 @@ import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
-import static seedu.address.testutil.TypicalAddressBook.getTypicalAddressBook;
 
 import org.junit.jupiter.api.Test;
 
 import seedu.address.commons.core.index.Index;
 import seedu.address.logic.commands.tag.EditCommand;
-import seedu.address.model.Model;
-import seedu.address.model.ModelManager;
-import seedu.address.model.UserPrefs;
 
 class EditCommandParserTest {
 
@@ -20,8 +16,6 @@ class EditCommandParserTest {
     private static final String MINIONS = "minions";
 
     private EditCommandParser parser = new EditCommandParser();
-
-    private Model model = new ModelManager(getTypicalAddressBook(), new UserPrefs());
 
     @Test
     public void parse_validInput_returnsEditCommand() {

--- a/src/test/java/seedu/address/testutil/TypicalSaleTags.java
+++ b/src/test/java/seedu/address/testutil/TypicalSaleTags.java
@@ -9,4 +9,5 @@ public class TypicalSaleTags {
     public static final Tag IMPORTANT = new Tag("important");
     public static final Tag FOLLOW_UP = new Tag("followUp");
     public static final Tag PENDING = new Tag("pending");
+    public static final Tag SPORTS = new Tag("sports");
 }


### PR DESCRIPTION
Closes #117 and #118.

Add `tag add` command.
A tag must exist first before the user can use this tag when creating or editing contacts / sales.
<img width="1270" alt="Screenshot 2020-10-18 at 8 56 55 PM" src="https://user-images.githubusercontent.com/58675456/96368142-c564b980-1184-11eb-8e86-63b05b7f1ee5.png">