### PR TITLE
Add command to update reminders

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -141,7 +141,7 @@ Examples:
 * `contact find s/ desc` sorts the contact list based on the total sales amount in non-ascending order
 
 #### Deleting a contact: `contact delete`
-Deletes the specified contact from StonksBook.
+Deletes the specified contact from StonksBook. All associated reminders and meetings will be deleted as well.
 
 Format: `contact delete INDEX`
 * Deletes the contact at the specified `INDEX`.

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -308,6 +308,19 @@ Format: `reminder add c/CONTACT_INDEX m/MESSAGE d/DATETIME`
 Examples:
 * `reminder add c/2 m/Send follow-up email d/2020-10-30 15:00` Adds a reminder associated with the 2nd contact that is scheduled for 30th October 2020 3PM, with the message `Send follow-up email`
 
+#### Editing a reminder: `reminder edit`
+Edits an existing reminder in StonksBook.
+
+Format: `reminder edit INDEX [c/CONTACT_INDEX] [m/MESSAGE] [d/DATETIME]`
+
+* Edits the reminder at the specified `INDEX`. The index refers to the index number shown in the displayed reminder list. The index must be a positive integer 1, 2, 3, …​
+* At least one of the optional fields must be provided.
+* Existing values will be updated to the input values.
+
+Examples:
+* `reminder edit 1 c/2` edits the associated contact of the 1st reminder to be the second contact in the displayed contact list.
+* `reminder edit 3 m/Follow up call d/2020-11-28 13:00` edits the message and scheduled date of the 3rd reminder to be "Follow up call" and "28th November 2020, 1PM" respectively.
+
 #### Listing all reminders: `reminder list`
 
 Shows a list of all reminders created, sorted in increasing order based on the date the reminder is scheduled.

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -318,7 +318,7 @@ Format: `reminder edit INDEX [c/CONTACT_INDEX] [m/MESSAGE] [d/DATETIME]`
 * Existing values will be updated to the input values.
 
 Examples:
-* `reminder edit 1 c/2` edits the associated contact of the 1st reminder to be the second contact in the displayed contact list.
+* `reminder edit 1 c/2` edits the 1st reminder to be associated with the second contact in the displayed contact list.
 * `reminder edit 3 m/Follow up call d/2020-11-28 13:00` edits the message and scheduled date of the 3rd reminder to be "Follow up call" and "28th November 2020, 1PM" respectively.
 
 #### Listing all reminders: `reminder list`

--- a/src/main/java/seedu/address/logic/commands/meeting/AddCommand.java
+++ b/src/main/java/seedu/address/logic/commands/meeting/AddCommand.java
@@ -16,6 +16,7 @@ import seedu.address.commons.core.index.Index;
 import seedu.address.logic.commands.Command;
 import seedu.address.logic.commands.CommandResult;
 import seedu.address.logic.commands.exceptions.CommandException;
+import seedu.address.model.Message;
 import seedu.address.model.Model;
 import seedu.address.model.meeting.Meeting;
 import seedu.address.model.person.Person;
@@ -46,7 +47,7 @@ public class AddCommand extends Command {
      * Index of the Person to be associated with this meeting.
      */
     private final Index index;
-    private final String message;
+    private final Message message;
     private final LocalDateTime startDate;
     private final Duration duration;
 
@@ -58,7 +59,7 @@ public class AddCommand extends Command {
      * @param startDate The start date of the Meeting.
      * @param duration  The duration of the Meeting.
      */
-    public AddCommand(Index index, String message, LocalDateTime startDate, Duration duration) {
+    public AddCommand(Index index, Message message, LocalDateTime startDate, Duration duration) {
         requireAllNonNull(index, message, startDate, duration);
         this.index = index;
         this.message = message;

--- a/src/main/java/seedu/address/logic/commands/reminder/AddCommand.java
+++ b/src/main/java/seedu/address/logic/commands/reminder/AddCommand.java
@@ -14,6 +14,7 @@ import seedu.address.commons.core.index.Index;
 import seedu.address.logic.commands.Command;
 import seedu.address.logic.commands.CommandResult;
 import seedu.address.logic.commands.exceptions.CommandException;
+import seedu.address.model.Message;
 import seedu.address.model.Model;
 import seedu.address.model.person.Person;
 import seedu.address.model.reminder.Reminder;
@@ -42,7 +43,7 @@ public class AddCommand extends Command {
      * Index of the Person to be associated with this reminder.
      */
     private final Index index;
-    private final String message;
+    private final Message message;
     private final LocalDateTime scheduledDate;
 
     /**
@@ -52,7 +53,7 @@ public class AddCommand extends Command {
      * @param message       The message associated with this reminder.
      * @param scheduledDate The scheduled date of the reminder.
      */
-    public AddCommand(Index index, String message, LocalDateTime scheduledDate) {
+    public AddCommand(Index index, Message message, LocalDateTime scheduledDate) {
         requireAllNonNull(index, message, scheduledDate);
         this.index = index;
         this.message = message;

--- a/src/main/java/seedu/address/logic/commands/reminder/EditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/reminder/EditCommand.java
@@ -15,6 +15,7 @@ import seedu.address.commons.util.CollectionUtil;
 import seedu.address.logic.commands.Command;
 import seedu.address.logic.commands.CommandResult;
 import seedu.address.logic.commands.exceptions.CommandException;
+import seedu.address.model.Message;
 import seedu.address.model.Model;
 import seedu.address.model.person.Person;
 import seedu.address.model.reminder.Reminder;
@@ -91,7 +92,7 @@ public class EditCommand extends Command {
         Person updatedPerson =
                 editReminderDescriptor.getContactIndex().map(index -> lastShownPersonsList.get(index.getZeroBased()))
                         .orElse(reminderToEdit.getPerson());
-        String updatedMessage = editReminderDescriptor.getMessage().orElse(reminderToEdit.getMessage());
+        Message updatedMessage = editReminderDescriptor.getMessage().orElse(reminderToEdit.getMessage());
         LocalDateTime updatedScheduledDate =
                 editReminderDescriptor.getScheduledDate().orElse(reminderToEdit.getScheduledDate());
 
@@ -122,7 +123,7 @@ public class EditCommand extends Command {
      */
     public static class EditReminderDescriptor {
         private Index contactIndex;
-        private String message;
+        private Message message;
         private LocalDateTime scheduledDate;
 
         public EditReminderDescriptor() {
@@ -153,11 +154,11 @@ public class EditCommand extends Command {
             return Optional.ofNullable(contactIndex);
         }
 
-        public void setMessage(String message) {
+        public void setMessage(Message message) {
             this.message = message;
         }
 
-        public Optional<String> getMessage() {
+        public Optional<Message> getMessage() {
             return Optional.ofNullable(message);
         }
 

--- a/src/main/java/seedu/address/logic/commands/reminder/EditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/reminder/EditCommand.java
@@ -1,0 +1,190 @@
+package seedu.address.logic.commands.reminder;
+
+import static java.util.Objects.requireNonNull;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_CONTACT;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_DATETIME;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_MESSAGE;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+import seedu.address.commons.core.Messages;
+import seedu.address.commons.core.index.Index;
+import seedu.address.commons.util.CollectionUtil;
+import seedu.address.logic.commands.Command;
+import seedu.address.logic.commands.CommandResult;
+import seedu.address.logic.commands.exceptions.CommandException;
+import seedu.address.model.Model;
+import seedu.address.model.person.Person;
+import seedu.address.model.reminder.Reminder;
+
+/**
+ * Edits the details of an existing reminder in the address book.
+ */
+public class EditCommand extends Command {
+
+    public static final String COMMAND_WORD = "reminder edit";
+
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Edits the details of the reminder identified "
+            + "by the index number used in the displayed reminder list. "
+            + "Existing values will be overwritten by the input values.\n"
+            + "Parameters: INDEX (must be a positive integer) "
+            + "[" + PREFIX_CONTACT + "CONTACT_INDEX] "
+            + "[" + PREFIX_MESSAGE + "MESSAGE] "
+            + "[" + PREFIX_DATETIME + "DATETIME] "
+            + "Example: " + COMMAND_WORD + " 1 "
+            + PREFIX_MESSAGE + "Follow up with Bob "
+            + PREFIX_DATETIME + "2020-11-30 12:30";
+
+    public static final String MESSAGE_EDIT_REMINDER_SUCCESS = "Edited Reminder: %1$s";
+    public static final String MESSAGE_NOT_EDITED = "At least one field to edit must be provided.";
+    public static final String MESSAGE_DUPLICATE_REMINDER = "This reminder already exists in the address book.";
+
+    private final Index index;
+    private final EditReminderDescriptor editReminderDescriptor;
+
+    /**
+     * @param index                  of the reminder in the filtered reminder list to edit.
+     * @param editReminderDescriptor details to edit the reminder with.
+     */
+    public EditCommand(Index index, EditReminderDescriptor editReminderDescriptor) {
+        requireNonNull(index);
+        requireNonNull(editReminderDescriptor);
+
+        this.index = index;
+        this.editReminderDescriptor = new EditReminderDescriptor(editReminderDescriptor);
+    }
+
+    @Override
+    public CommandResult execute(Model model) throws CommandException {
+        requireNonNull(model);
+        List<Reminder> lastShownList = model.getSortedReminderList();
+
+        if (index.getZeroBased() >= lastShownList.size()) {
+            throw new CommandException(Messages.MESSAGE_INVALID_REMINDER_DISPLAYED_INDEX);
+        }
+
+        Reminder reminderToEdit = lastShownList.get(index.getZeroBased());
+        Reminder editedReminder = createEditedReminder(model, reminderToEdit, editReminderDescriptor);
+
+        if (!reminderToEdit.equals(editedReminder) && model.hasReminder(editedReminder)) {
+            throw new CommandException(MESSAGE_DUPLICATE_REMINDER);
+        }
+
+        model.setReminder(reminderToEdit, editedReminder);
+        return new CommandResult(String.format(MESSAGE_EDIT_REMINDER_SUCCESS, editedReminder));
+    }
+
+    /**
+     * Creates and returns a {@code Reminder} with the details of {@code reminderToEdit}
+     * edited with {@code editReminderDescriptor}.
+     */
+    private static Reminder createEditedReminder(Model model, Reminder reminderToEdit,
+                                                 EditReminderDescriptor editReminderDescriptor) {
+        assert reminderToEdit != null;
+        assert editReminderDescriptor != null;
+
+        List<Person> lastShownPersonsList = model.getSortedPersonList();
+
+        Person updatedPerson =
+                editReminderDescriptor.getPersonIndex().map(index -> lastShownPersonsList.get(index.getZeroBased()))
+                        .orElse(reminderToEdit.getPerson());
+        String updatedMessage = editReminderDescriptor.getMessage().orElse(reminderToEdit.getMessage());
+        LocalDateTime updatedScheduledDate =
+                editReminderDescriptor.getScheduledDate().orElse(reminderToEdit.getScheduledDate());
+
+        return new Reminder(updatedPerson, updatedMessage, updatedScheduledDate);
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        // short circuit if same object
+        if (other == this) {
+            return true;
+        }
+
+        // instanceof handles nulls
+        if (!(other instanceof EditCommand)) {
+            return false;
+        }
+
+        // state check
+        EditCommand e = (EditCommand) other;
+        return index.equals(e.index)
+                && editReminderDescriptor.equals(e.editReminderDescriptor);
+    }
+
+    /**
+     * Stores the details to edit the reminder with. Each non-empty field value will replace the
+     * corresponding field value of the reminder.
+     */
+    public static class EditReminderDescriptor {
+        private Index personIndex;
+        private String message;
+        private LocalDateTime scheduledDate;
+
+        public EditReminderDescriptor() {
+        }
+
+        /**
+         * A constructor that is used to create a Copy of the provided @{code EditReminderDescriptor}.
+         */
+        public EditReminderDescriptor(EditReminderDescriptor toCopy) {
+            setPersonIndex(toCopy.personIndex);
+            setMessage(toCopy.message);
+            setScheduledDate(toCopy.scheduledDate);
+        }
+
+        /**
+         * Returns true if at least one field is edited.
+         */
+        public boolean isAnyFieldEdited() {
+            return CollectionUtil.isAnyNonNull(personIndex, message, scheduledDate);
+        }
+
+        public void setPersonIndex(Index personIndex) {
+            this.personIndex = personIndex;
+        }
+
+        public Optional<Index> getPersonIndex() {
+            return Optional.ofNullable(personIndex);
+        }
+
+        public void setMessage(String message) {
+            this.message = message;
+        }
+
+        public Optional<String> getMessage() {
+            return Optional.ofNullable(message);
+        }
+
+        public void setScheduledDate(LocalDateTime scheduledDate) {
+            this.scheduledDate = scheduledDate;
+        }
+
+        public Optional<LocalDateTime> getScheduledDate() {
+            return Optional.ofNullable(scheduledDate);
+        }
+
+        @Override
+        public boolean equals(Object other) {
+            // short circuit if same object
+            if (other == this) {
+                return true;
+            }
+
+            // instanceof handles nulls
+            if (!(other instanceof EditReminderDescriptor)) {
+                return false;
+            }
+
+            // state check
+            EditReminderDescriptor e = (EditReminderDescriptor) other;
+
+            return getPersonIndex().equals(e.getPersonIndex())
+                    && getMessage().equals(e.getMessage())
+                    && getScheduledDate().equals(e.getScheduledDate());
+        }
+    }
+}

--- a/src/main/java/seedu/address/logic/commands/reminder/EditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/reminder/EditCommand.java
@@ -82,6 +82,7 @@ public class EditCommand extends Command {
      */
     private static Reminder createEditedReminder(Model model, Reminder reminderToEdit,
                                                  EditReminderDescriptor editReminderDescriptor) {
+        assert model != null;
         assert reminderToEdit != null;
         assert editReminderDescriptor != null;
 
@@ -131,6 +132,7 @@ public class EditCommand extends Command {
          * A constructor that is used to create a Copy of the provided @{code EditReminderDescriptor}.
          */
         public EditReminderDescriptor(EditReminderDescriptor toCopy) {
+            assert toCopy != null;
             setContactIndex(toCopy.contactIndex);
             setMessage(toCopy.message);
             setScheduledDate(toCopy.scheduledDate);

--- a/src/main/java/seedu/address/logic/commands/reminder/EditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/reminder/EditCommand.java
@@ -88,7 +88,7 @@ public class EditCommand extends Command {
         List<Person> lastShownPersonsList = model.getSortedPersonList();
 
         Person updatedPerson =
-                editReminderDescriptor.getPersonIndex().map(index -> lastShownPersonsList.get(index.getZeroBased()))
+                editReminderDescriptor.getContactIndex().map(index -> lastShownPersonsList.get(index.getZeroBased()))
                         .orElse(reminderToEdit.getPerson());
         String updatedMessage = editReminderDescriptor.getMessage().orElse(reminderToEdit.getMessage());
         LocalDateTime updatedScheduledDate =
@@ -120,7 +120,7 @@ public class EditCommand extends Command {
      * corresponding field value of the reminder.
      */
     public static class EditReminderDescriptor {
-        private Index personIndex;
+        private Index contactIndex;
         private String message;
         private LocalDateTime scheduledDate;
 
@@ -131,7 +131,7 @@ public class EditCommand extends Command {
          * A constructor that is used to create a Copy of the provided @{code EditReminderDescriptor}.
          */
         public EditReminderDescriptor(EditReminderDescriptor toCopy) {
-            setPersonIndex(toCopy.personIndex);
+            setContactIndex(toCopy.contactIndex);
             setMessage(toCopy.message);
             setScheduledDate(toCopy.scheduledDate);
         }
@@ -140,15 +140,15 @@ public class EditCommand extends Command {
          * Returns true if at least one field is edited.
          */
         public boolean isAnyFieldEdited() {
-            return CollectionUtil.isAnyNonNull(personIndex, message, scheduledDate);
+            return CollectionUtil.isAnyNonNull(contactIndex, message, scheduledDate);
         }
 
-        public void setPersonIndex(Index personIndex) {
-            this.personIndex = personIndex;
+        public void setContactIndex(Index contactIndex) {
+            this.contactIndex = contactIndex;
         }
 
-        public Optional<Index> getPersonIndex() {
-            return Optional.ofNullable(personIndex);
+        public Optional<Index> getContactIndex() {
+            return Optional.ofNullable(contactIndex);
         }
 
         public void setMessage(String message) {
@@ -182,7 +182,7 @@ public class EditCommand extends Command {
             // state check
             EditReminderDescriptor e = (EditReminderDescriptor) other;
 
-            return getPersonIndex().equals(e.getPersonIndex())
+            return getContactIndex().equals(e.getContactIndex())
                     && getMessage().equals(e.getMessage())
                     && getScheduledDate().equals(e.getScheduledDate());
         }

--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -16,6 +16,7 @@ import java.util.stream.Stream;
 import seedu.address.commons.core.index.Index;
 import seedu.address.commons.util.StringUtil;
 import seedu.address.logic.parser.exceptions.ParseException;
+import seedu.address.model.Message;
 import seedu.address.model.person.Address;
 import seedu.address.model.person.Email;
 import seedu.address.model.person.Name;
@@ -150,6 +151,21 @@ public class ParserUtil {
             tagSet.add(parseTag(tagName));
         }
         return tagSet;
+    }
+
+    /**
+     * Parses a {@code String message} into a {@code Message}.
+     * Leading and trailing whitespaces will be trimmed.
+     *
+     * @throws ParseException if the given {@code message} is invalid.
+     */
+    public static Message parseMessage(String message) throws ParseException {
+        requireNonNull(message);
+        String trimmedMessage = message.strip();
+        if (!Message.isValidMessage(trimmedMessage)) {
+            throw new ParseException(Message.MESSAGE_CONSTRAINTS);
+        }
+        return new Message(trimmedMessage);
     }
 
     /**

--- a/src/main/java/seedu/address/logic/parser/meeting/AddCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/meeting/AddCommandParser.java
@@ -17,6 +17,7 @@ import seedu.address.logic.parser.ArgumentTokenizer;
 import seedu.address.logic.parser.Parser;
 import seedu.address.logic.parser.ParserUtil;
 import seedu.address.logic.parser.exceptions.ParseException;
+import seedu.address.model.Message;
 
 /**
  * Parses input arguments and creates a new AddCommand object for Meeting.
@@ -47,7 +48,7 @@ public class AddCommandParser implements Parser<AddCommand> {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddCommand.MESSAGE_USAGE), pe);
         }
 
-        String message = argMultimap.getValue(PREFIX_MESSAGE).get();
+        Message message = ParserUtil.parseMessage(argMultimap.getValue(PREFIX_MESSAGE).get());
         LocalDateTime startDate = ParserUtil.parseDateTime(argMultimap.getValue(PREFIX_DATETIME).get());
         Duration duration = ParserUtil.parseDuration(argMultimap.getValue(PREFIX_DURATION).get());
         return new AddCommand(index, message, startDate, duration);

--- a/src/main/java/seedu/address/logic/parser/reminder/AddCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/reminder/AddCommandParser.java
@@ -15,6 +15,7 @@ import seedu.address.logic.parser.ArgumentTokenizer;
 import seedu.address.logic.parser.Parser;
 import seedu.address.logic.parser.ParserUtil;
 import seedu.address.logic.parser.exceptions.ParseException;
+import seedu.address.model.Message;
 
 /**
  * Parses input arguments and creates a new AddCommand object for Reminder.
@@ -45,7 +46,7 @@ public class AddCommandParser implements Parser<AddCommand> {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddCommand.MESSAGE_USAGE), pe);
         }
 
-        String message = argMultimap.getValue(PREFIX_MESSAGE).get();
+        Message message = ParserUtil.parseMessage(argMultimap.getValue(PREFIX_MESSAGE).get());
         LocalDateTime scheduledDate = ParserUtil.parseDateTime(argMultimap.getValue(PREFIX_DATETIME).get());
 
         return new AddCommand(index, message, scheduledDate);

--- a/src/main/java/seedu/address/logic/parser/reminder/EditCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/reminder/EditCommandParser.java
@@ -44,7 +44,7 @@ public class EditCommandParser implements Parser<EditCommand> {
             editReminderDescriptor.setContactIndex(ParserUtil.parseIndex(argMultimap.getValue(PREFIX_CONTACT).get()));
         }
         if (argMultimap.getValue(PREFIX_MESSAGE).isPresent()) {
-            editReminderDescriptor.setMessage(argMultimap.getValue(PREFIX_MESSAGE).get());
+            editReminderDescriptor.setMessage(ParserUtil.parseMessage(argMultimap.getValue(PREFIX_MESSAGE).get()));
         }
         if (argMultimap.getValue(PREFIX_DATETIME).isPresent()) {
             editReminderDescriptor

--- a/src/main/java/seedu/address/logic/parser/reminder/EditCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/reminder/EditCommandParser.java
@@ -41,7 +41,7 @@ public class EditCommandParser implements Parser<EditCommand> {
 
         EditReminderDescriptor editReminderDescriptor = new EditReminderDescriptor();
         if (argMultimap.getValue(PREFIX_CONTACT).isPresent()) {
-            editReminderDescriptor.setPersonIndex(ParserUtil.parseIndex(argMultimap.getValue(PREFIX_CONTACT).get()));
+            editReminderDescriptor.setContactIndex(ParserUtil.parseIndex(argMultimap.getValue(PREFIX_CONTACT).get()));
         }
         if (argMultimap.getValue(PREFIX_MESSAGE).isPresent()) {
             editReminderDescriptor.setMessage(argMultimap.getValue(PREFIX_MESSAGE).get());

--- a/src/main/java/seedu/address/logic/parser/reminder/EditCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/reminder/EditCommandParser.java
@@ -1,0 +1,60 @@
+package seedu.address.logic.parser.reminder;
+
+import static java.util.Objects.requireNonNull;
+import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_CONTACT;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_DATETIME;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_MESSAGE;
+
+import seedu.address.commons.core.index.Index;
+import seedu.address.logic.commands.reminder.EditCommand;
+import seedu.address.logic.commands.reminder.EditCommand.EditReminderDescriptor;
+import seedu.address.logic.parser.ArgumentMultimap;
+import seedu.address.logic.parser.ArgumentTokenizer;
+import seedu.address.logic.parser.Parser;
+import seedu.address.logic.parser.ParserUtil;
+import seedu.address.logic.parser.exceptions.ParseException;
+
+/**
+ * Parses input arguments and creates a new EditCommand object for Reminder
+ */
+public class EditCommandParser implements Parser<EditCommand> {
+
+    /**
+     * Parses the given {@code String} of arguments in the context of the EditCommand
+     * and returns an EditCommand object for execution.
+     *
+     * @throws ParseException if the user input does not conform the expected format
+     */
+    public EditCommand parse(String args) throws ParseException {
+        requireNonNull(args);
+        ArgumentMultimap argMultimap =
+                ArgumentTokenizer.tokenize(args, PREFIX_CONTACT, PREFIX_MESSAGE, PREFIX_DATETIME);
+
+        Index index;
+
+        try {
+            index = ParserUtil.parseIndex(argMultimap.getPreamble());
+        } catch (ParseException pe) {
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, EditCommand.MESSAGE_USAGE), pe);
+        }
+
+        EditReminderDescriptor editReminderDescriptor = new EditReminderDescriptor();
+        if (argMultimap.getValue(PREFIX_CONTACT).isPresent()) {
+            editReminderDescriptor.setPersonIndex(ParserUtil.parseIndex(argMultimap.getValue(PREFIX_CONTACT).get()));
+        }
+        if (argMultimap.getValue(PREFIX_MESSAGE).isPresent()) {
+            editReminderDescriptor.setMessage(argMultimap.getValue(PREFIX_MESSAGE).get());
+        }
+        if (argMultimap.getValue(PREFIX_DATETIME).isPresent()) {
+            editReminderDescriptor
+                    .setScheduledDate(ParserUtil.parseDateTime(argMultimap.getValue(PREFIX_DATETIME).get()));
+        }
+
+        if (!editReminderDescriptor.isAnyFieldEdited()) {
+            throw new ParseException(EditCommand.MESSAGE_NOT_EDITED);
+        }
+
+        return new EditCommand(index, editReminderDescriptor);
+    }
+}

--- a/src/main/java/seedu/address/logic/parser/reminder/ReminderCommandsParser.java
+++ b/src/main/java/seedu/address/logic/parser/reminder/ReminderCommandsParser.java
@@ -7,6 +7,7 @@ import seedu.address.logic.commands.Command;
 import seedu.address.logic.commands.UnknownCommand;
 import seedu.address.logic.commands.reminder.AddCommand;
 import seedu.address.logic.commands.reminder.DeleteCommand;
+import seedu.address.logic.commands.reminder.EditCommand;
 import seedu.address.logic.commands.reminder.ListCommand;
 import seedu.address.logic.parser.GroupCommandsParser;
 import seedu.address.logic.parser.exceptions.ParseException;
@@ -19,7 +20,8 @@ public class ReminderCommandsParser implements GroupCommandsParser {
     public static final List<String> ALL_REMINDER_COMMAND_WORDS = Arrays.asList(
             AddCommand.COMMAND_WORD,
             DeleteCommand.COMMAND_WORD,
-            ListCommand.COMMAND_WORD
+            ListCommand.COMMAND_WORD,
+            EditCommand.COMMAND_WORD
     );
 
     /**
@@ -41,6 +43,9 @@ public class ReminderCommandsParser implements GroupCommandsParser {
 
         case ListCommand.COMMAND_WORD:
             return new ListCommand();
+
+        case EditCommand.COMMAND_WORD:
+            return new EditCommandParser().parse(arguments);
 
         default:
             return new UnknownCommand(commandWord);

--- a/src/main/java/seedu/address/model/AddressBook.java
+++ b/src/main/java/seedu/address/model/AddressBook.java
@@ -1,6 +1,7 @@
 package seedu.address.model;
 
 import static java.util.Objects.requireNonNull;
+import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
 
 import java.util.HashSet;
 import java.util.List;
@@ -354,6 +355,17 @@ public class AddressBook implements ReadOnlyAddressBook {
      */
     public void removeReminder(Reminder key) {
         reminders.remove(key);
+    }
+
+    /**
+     * Replaces the given reminder {@code target} in the list with {@code editedReminder}.
+     * {@code target} must exist in the address book.
+     * The reminder {@code editedReminder} must not be the same as another existing reminder in the address book.
+     */
+    public void setReminder(Reminder target, Reminder editedReminder) {
+        requireAllNonNull(target, editedReminder);
+
+        reminders.setReminder(target, editedReminder);
     }
 
     /**

--- a/src/main/java/seedu/address/model/Message.java
+++ b/src/main/java/seedu/address/model/Message.java
@@ -1,0 +1,61 @@
+package seedu.address.model;
+
+import static java.util.Objects.requireNonNull;
+import static seedu.address.commons.util.AppUtil.checkArgument;
+
+/**
+ * Represents an attribute that stores text cannot be blank, and should only contain alphanumeric characters
+ * and spaces.
+ * Guarantees: immutable; is valid as declared in {@link #isValidMessage(String)}
+ */
+public class Message {
+
+    public static final String MESSAGE_CONSTRAINTS =
+            "Messages should only contain alphanumeric characters and spaces, and it should not be blank";
+
+    /*
+     * The first character of the address must not be a whitespace,
+     * otherwise " " (a blank string) becomes a valid input.
+     */
+    public static final String VALIDATION_REGEX = "[\\p{Alnum}][\\p{Alnum} ]*";
+
+    public final String message;
+
+    /**
+     * Constructs a {@code Message}.
+     *
+     * @param message A valid message.
+     */
+    public Message(String message) {
+        requireNonNull(message);
+        checkArgument(isValidMessage(message), MESSAGE_CONSTRAINTS);
+        this.message = message;
+    }
+
+    /**
+     * Returns true if a given string is a valid message.
+     */
+    public static boolean isValidMessage(String test) {
+        return test.matches(VALIDATION_REGEX);
+    }
+
+
+    @Override
+    public String toString() {
+        return message;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return other == this // short circuit if same object
+                || (other instanceof Message // instanceof handles nulls
+                // Case-insensitive equality checking
+                && message.strip().toLowerCase().equals(((Message) other).message.strip().toLowerCase()));
+    }
+
+    @Override
+    public int hashCode() {
+        return message.hashCode();
+    }
+
+}

--- a/src/main/java/seedu/address/model/Model.java
+++ b/src/main/java/seedu/address/model/Model.java
@@ -228,6 +228,14 @@ public interface Model {
     void addReminder(Reminder reminder);
 
     /**
+     * Replaces the given reminder {@code target} with {@code editedReminder}.
+     * {@code target} must exist in the address book.
+     * The reminder {@code editedReminder} must not be the same as another existing reminder in the address
+     * book.
+     */
+    void setReminder(Reminder target, Reminder editedReminder);
+
+    /**
      * Adds the given sale item to the specified contact.
      */
     void addSaleToPerson(Person person, Sale sale);

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -205,6 +205,12 @@ public class ModelManager implements Model {
     }
 
     @Override
+    public void setReminder(Reminder target, Reminder editedReminder) {
+        requireAllNonNull(target, editedReminder);
+        this.addressBook.setReminder(target, editedReminder);
+    }
+
+    @Override
     public void addSaleToPerson(Person person, Sale sale) {
         addressBook.addSaleToPerson(person, sale);
     }

--- a/src/main/java/seedu/address/model/meeting/Meeting.java
+++ b/src/main/java/seedu/address/model/meeting/Meeting.java
@@ -8,6 +8,7 @@ import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.Objects;
 
+import seedu.address.model.Message;
 import seedu.address.model.person.Person;
 
 /**
@@ -23,7 +24,7 @@ public class Meeting implements Comparable<Meeting> {
     private static final DateTimeFormatter TIME_FORMATTER = DateTimeFormatter.ofPattern("HH:mm");
 
     private final Person person;
-    private final String message;
+    private final Message message;
     private final LocalDateTime startDate;
     private final Duration duration;
 
@@ -35,10 +36,10 @@ public class Meeting implements Comparable<Meeting> {
      * @param startDate The date this meeting starts.
      * @param duration  The duration of the meeting.
      */
-    public Meeting(Person person, String message, LocalDateTime startDate, Duration duration) {
+    public Meeting(Person person, Message message, LocalDateTime startDate, Duration duration) {
         requireAllNonNull(person, message, startDate, duration);
         this.person = person;
-        this.message = message.strip();
+        this.message = message;
         this.startDate = startDate;
         this.duration = duration;
     }
@@ -47,7 +48,7 @@ public class Meeting implements Comparable<Meeting> {
         return this.person;
     }
 
-    public String getMessage() {
+    public Message getMessage() {
         return this.message;
     }
 
@@ -107,8 +108,7 @@ public class Meeting implements Comparable<Meeting> {
         Meeting otherMeeting = (Meeting) other;
 
         return this.person.equals(otherMeeting.person)
-                // Case-insensitive equality checking
-                && this.message.toLowerCase().equals(otherMeeting.message.toLowerCase())
+                && this.message.equals(otherMeeting.message)
                 && this.startDate.equals(otherMeeting.startDate)
                 && this.duration.equals(otherMeeting.duration);
     }

--- a/src/main/java/seedu/address/model/reminder/Reminder.java
+++ b/src/main/java/seedu/address/model/reminder/Reminder.java
@@ -6,6 +6,7 @@ import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.Objects;
 
+import seedu.address.model.Message;
 import seedu.address.model.person.Person;
 
 /**
@@ -17,7 +18,7 @@ public class Reminder implements Comparable<Reminder> {
     private static final DateTimeFormatter DATE_TIME_FORMATTER = DateTimeFormatter.ofPattern("E, dd MMM yyyy, HH:mm");
 
     private final Person person;
-    private final String message;
+    private final Message message;
     private final LocalDateTime scheduledDate;
 
     /**
@@ -27,10 +28,10 @@ public class Reminder implements Comparable<Reminder> {
      * @param message       The message associated with this reminder.
      * @param scheduledDate The date this reminder is scheduled for.
      */
-    public Reminder(Person person, String message, LocalDateTime scheduledDate) {
+    public Reminder(Person person, Message message, LocalDateTime scheduledDate) {
         requireAllNonNull(person, message, scheduledDate);
         this.person = person;
-        this.message = message.strip();
+        this.message = message;
         this.scheduledDate = scheduledDate;
     }
 
@@ -38,7 +39,7 @@ public class Reminder implements Comparable<Reminder> {
         return this.person;
     }
 
-    public String getMessage() {
+    public Message getMessage() {
         return this.message;
     }
 
@@ -91,8 +92,7 @@ public class Reminder implements Comparable<Reminder> {
         Reminder otherReminder = (Reminder) other;
 
         return this.person.equals(otherReminder.person)
-                // Case-insensitive equality checking
-                && this.message.toLowerCase().equals(otherReminder.message.toLowerCase())
+                && this.message.equals(otherReminder.message)
                 && this.scheduledDate.equals(otherReminder.scheduledDate);
     }
 

--- a/src/main/java/seedu/address/model/reminder/UniqueReminderList.java
+++ b/src/main/java/seedu/address/model/reminder/UniqueReminderList.java
@@ -90,6 +90,26 @@ public class UniqueReminderList implements Iterable<Reminder> {
     }
 
     /**
+     * Replaces the reminder {@code target} in the list with {@code editedReminder}.
+     * {@code target} must exist in the list.
+     * The reminder {@code editedReminder} must not be the same as another existing reminder in the list.
+     */
+    public void setReminder(Reminder target, Reminder editedReminder) {
+        requireAllNonNull(target, editedReminder);
+
+        int index = internalList.indexOf(target);
+        if (index == -1) {
+            throw new ReminderNotFoundException();
+        }
+
+        if (!target.equals(editedReminder) && contains(editedReminder)) {
+            throw new DuplicateReminderException();
+        }
+
+        internalList.set(index, editedReminder);
+    }
+
+    /**
      * Returns the backing list as an unmodifiable {@code ObservableList}.
      */
     public ObservableList<Reminder> asUnmodifiableObservableList() {

--- a/src/main/java/seedu/address/model/util/SampleDataUtil.java
+++ b/src/main/java/seedu/address/model/util/SampleDataUtil.java
@@ -99,9 +99,9 @@ public class SampleDataUtil {
         Person charlotte = samplePersons[2];
 
         UniqueMeetingList meetings = new UniqueMeetingList();
-        meetings.add(new Meeting(bernice, "Sales Call",
+        meetings.add(new Meeting(bernice, new Message("Sales Call"),
                 LocalDateTime.of(2020, 11, 20, 15, 30), Duration.ofMinutes(30)));
-        meetings.add(new Meeting(charlotte, "Lunch to discuss new recurring purchase requirements",
+        meetings.add(new Meeting(charlotte, new Message("Lunch to discuss new recurring purchase requirements"),
                 LocalDateTime.of(2020, 12, 20, 12, 0), Duration.ofMinutes(90)));
 
         return meetings;

--- a/src/main/java/seedu/address/model/util/SampleDataUtil.java
+++ b/src/main/java/seedu/address/model/util/SampleDataUtil.java
@@ -8,6 +8,7 @@ import java.util.Set;
 import java.util.stream.Collectors;
 
 import seedu.address.model.AddressBook;
+import seedu.address.model.Message;
 import seedu.address.model.ReadOnlyAddressBook;
 import seedu.address.model.meeting.Meeting;
 import seedu.address.model.meeting.UniqueMeetingList;
@@ -84,9 +85,9 @@ public class SampleDataUtil {
         Person charlotte = samplePersons[2];
 
         UniqueReminderList reminders = new UniqueReminderList();
-        reminders.add(new Reminder(alex, "Send follow up email",
+        reminders.add(new Reminder(alex, new Message("Send follow up email"),
                 LocalDateTime.of(2020, 11, 30, 15, 30)));
-        reminders.add(new Reminder(charlotte, "Draft up sales proposal for upcoming meeting",
+        reminders.add(new Reminder(charlotte, new Message("Draft up sales proposal for upcoming meeting"),
                 LocalDateTime.of(2020, 12, 15, 9, 0)));
 
         return reminders;

--- a/src/main/java/seedu/address/storage/JsonAdaptedMeeting.java
+++ b/src/main/java/seedu/address/storage/JsonAdaptedMeeting.java
@@ -10,6 +10,7 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import seedu.address.commons.exceptions.IllegalValueException;
+import seedu.address.model.Message;
 import seedu.address.model.meeting.Meeting;
 import seedu.address.model.person.Person;
 
@@ -48,7 +49,7 @@ class JsonAdaptedMeeting {
      */
     public JsonAdaptedMeeting(Meeting source) {
         this.person = new JsonAdaptedPerson(source.getPerson());
-        this.message = source.getMessage();
+        this.message = source.getMessage().message;
         this.startDate = source.getStartDate().toString();
         this.duration = source.getDuration().toString();
     }
@@ -68,7 +69,7 @@ class JsonAdaptedMeeting {
         if (this.message == null) {
             throw new IllegalValueException(String.format(MISSING_FIELD_MESSAGE_FORMAT, "Message"));
         }
-        final String message = this.message;
+        final Message message = new Message(this.message);
 
         if (this.startDate == null) {
             throw new IllegalValueException(String.format(MISSING_FIELD_MESSAGE_FORMAT, "Start Date"));

--- a/src/main/java/seedu/address/storage/JsonAdaptedReminder.java
+++ b/src/main/java/seedu/address/storage/JsonAdaptedReminder.java
@@ -9,6 +9,7 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import seedu.address.commons.exceptions.IllegalValueException;
+import seedu.address.model.Message;
 import seedu.address.model.person.Person;
 import seedu.address.model.reminder.Reminder;
 
@@ -41,7 +42,7 @@ class JsonAdaptedReminder {
      */
     public JsonAdaptedReminder(Reminder source) {
         this.person = new JsonAdaptedPerson(source.getPerson());
-        this.message = source.getMessage();
+        this.message = source.getMessage().message;
         this.scheduledDate = source.getScheduledDate().toString();
     }
 
@@ -59,12 +60,11 @@ class JsonAdaptedReminder {
         if (this.message == null) {
             throw new IllegalValueException(String.format(MISSING_FIELD_MESSAGE_FORMAT, "Message"));
         }
-        final String message = this.message;
+        final Message message = new Message(this.message);
 
         if (this.scheduledDate == null) {
             throw new IllegalValueException(String.format(MISSING_FIELD_MESSAGE_FORMAT, "DateTime"));
         }
-
 
         final LocalDateTime scheduledDate;
         try {

--- a/src/main/java/seedu/address/ui/MeetingCard.java
+++ b/src/main/java/seedu/address/ui/MeetingCard.java
@@ -33,7 +33,7 @@ public class MeetingCard extends UiPart<Region> {
         super(FXML);
         this.meeting = meeting;
         id.setText(displayedIndex + ". ");
-        message.setText(meeting.getMessage());
+        message.setText(meeting.getMessage().message);
         date.setText(meeting.getFormattedStartEndDate());
         personName.setText(meeting.getPerson().getName().fullName);
     }

--- a/src/main/java/seedu/address/ui/ReminderCard.java
+++ b/src/main/java/seedu/address/ui/ReminderCard.java
@@ -46,7 +46,6 @@ public class ReminderCard extends UiPart<Region> {
         scheduledDate.setText(reminder.getFormattedScheduledDate());
         personName.setText(reminder.getPerson().getName().fullName);
 
-        //  TODO: Test that the colour updates properly when a reminder is updated
         if (reminder.isOverdue()) {
             setStyleToIndicateOverdue();
         }

--- a/src/main/java/seedu/address/ui/ReminderCard.java
+++ b/src/main/java/seedu/address/ui/ReminderCard.java
@@ -42,7 +42,7 @@ public class ReminderCard extends UiPart<Region> {
         super(FXML);
         this.reminder = reminder;
         id.setText(displayedIndex + ". ");
-        message.setText(reminder.getMessage());
+        message.setText(reminder.getMessage().message);
         scheduledDate.setText(reminder.getFormattedScheduledDate());
         personName.setText(reminder.getPerson().getName().fullName);
 

--- a/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
+++ b/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
@@ -19,6 +19,7 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_SALE_UNIT_PRICE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
 import static seedu.address.testutil.Assert.assertThrows;
 import static seedu.address.testutil.TypicalIndexes.INDEX_SECOND_ITEM;
+import static seedu.address.testutil.TypicalIndexes.INDEX_THIRD_ITEM;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -50,7 +51,10 @@ public class CommandTestUtil {
     public static final String VALID_TAG_HUSBAND = "husband";
     public static final String VALID_TAG_FRIEND = "friend";
     public static final String VALID_MESSAGE_CALL_AMY = "Call Amy";
+    public static final String VALID_MESSAGE_CALL_BOB = "Call Bob";
     public static final String VALID_DATE_1 = "2020-10-30 15:19";
+    public static final String VALID_DATE_2 = "2018-12-20 12:00";
+    public static final String VALID_DATE_3 = "2020-12-20 12:12";
     public static final String VALID_REMARK_AMY = "";
     public static final String VALID_REMARK_BOB = "Likes cats";
     public static final String VALID_DURATION_ONE_HOUR = "60";
@@ -68,8 +72,11 @@ public class CommandTestUtil {
     public static final String REMARK_DESC_AMY = " " + PREFIX_CONTACT_REMARK + VALID_REMARK_AMY;
     public static final String REMARK_DESC_BOB = " " + PREFIX_CONTACT_REMARK + VALID_REMARK_BOB;
     public static final String MESSAGE_CALL_AMY = " " + PREFIX_MESSAGE + VALID_MESSAGE_CALL_AMY;
+    public static final String MESSAGE_CALL_BOB = " " + PREFIX_MESSAGE + VALID_MESSAGE_CALL_BOB;
     public static final String DATE_1 = " " + PREFIX_DATETIME + VALID_DATE_1;
+    public static final String DATE_2 = " " + PREFIX_DATETIME + VALID_DATE_2;
     public static final String CONTACT_INDEX_SECOND = " " + PREFIX_CONTACT + INDEX_SECOND_ITEM.getOneBased();
+    public static final String CONTACT_INDEX_THIRD = " " + PREFIX_CONTACT + INDEX_THIRD_ITEM.getOneBased();
     public static final String DURATION_ONE_HOUR = " " + PREFIX_DURATION + VALID_DURATION_ONE_HOUR;
 
     public static final String INVALID_NAME_DESC = " " + PREFIX_CONTACT_NAME + "James&"; // '&' not allowed in names

--- a/src/test/java/seedu/address/logic/commands/contact/AddCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/contact/AddCommandTest.java
@@ -264,6 +264,11 @@ public class AddCommandTest {
         }
 
         @Override
+        public void setReminder(Reminder target, Reminder editedReminder) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
         public void addSaleToPerson(Person person, Sale sale) {
             throw new AssertionError("This method should not be called.");
         }

--- a/src/test/java/seedu/address/logic/commands/meeting/AddCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/meeting/AddCommandTest.java
@@ -19,6 +19,7 @@ import org.junit.jupiter.api.Test;
 
 import seedu.address.logic.commands.CommandResult;
 import seedu.address.logic.commands.exceptions.CommandException;
+import seedu.address.model.Message;
 import seedu.address.model.ModelStub;
 import seedu.address.model.ModelStubWithSortedPersonList;
 import seedu.address.model.meeting.Meeting;
@@ -26,7 +27,7 @@ import seedu.address.model.person.Person;
 import seedu.address.testutil.person.PersonBuilder;
 
 public class AddCommandTest {
-    private static final String MESSAGE = "message";
+    private static final Message MESSAGE = new Message("message");
 
     @Test
     public void constructor_nullIndex_throwsNullPointerException() {
@@ -79,15 +80,18 @@ public class AddCommandTest {
 
     @Test
     public void equals() {
+        Message lunchWithAlice = new Message("Lunch with Alice");
         AddCommand addLunchAliceMeetingCommand =
-                new AddCommand(INDEX_FIRST_ITEM, "Lunch with Alice", TYPICAL_DATE_1, TYPICAL_DURATION_ONE_HOUR);
+                new AddCommand(INDEX_FIRST_ITEM, lunchWithAlice, TYPICAL_DATE_1,
+                        TYPICAL_DURATION_ONE_HOUR);
 
         // same object -> returns true
         assertEquals(addLunchAliceMeetingCommand, addLunchAliceMeetingCommand);
 
         // same values -> returns true
         AddCommand addLunchAliceMeetingCommandCopy =
-                new AddCommand(INDEX_FIRST_ITEM, "Lunch with Alice", TYPICAL_DATE_1, TYPICAL_DURATION_ONE_HOUR);
+                new AddCommand(INDEX_FIRST_ITEM, lunchWithAlice, TYPICAL_DATE_1,
+                        TYPICAL_DURATION_ONE_HOUR);
         assertEquals(addLunchAliceMeetingCommand, addLunchAliceMeetingCommandCopy);
 
         // different types -> returns false
@@ -98,19 +102,23 @@ public class AddCommandTest {
 
         // different index -> returns false
         assertNotEquals(addLunchAliceMeetingCommand,
-                new AddCommand(INDEX_SECOND_ITEM, "Lunch with Alice", TYPICAL_DATE_1, TYPICAL_DURATION_ONE_HOUR));
+                new AddCommand(INDEX_SECOND_ITEM, lunchWithAlice, TYPICAL_DATE_1,
+                        TYPICAL_DURATION_ONE_HOUR));
 
         // different message -> returns false
         assertNotEquals(addLunchAliceMeetingCommand,
-                new AddCommand(INDEX_FIRST_ITEM, "Dinner with Alice", TYPICAL_DATE_1, TYPICAL_DURATION_ONE_HOUR));
+                new AddCommand(INDEX_FIRST_ITEM, new Message("Dinner with Alice"), TYPICAL_DATE_1,
+                        TYPICAL_DURATION_ONE_HOUR));
 
         // different date -> returns false
         assertNotEquals(addLunchAliceMeetingCommand,
-                new AddCommand(INDEX_FIRST_ITEM, "Lunch with Alice", TYPICAL_DATE_2, TYPICAL_DURATION_ONE_HOUR));
+                new AddCommand(INDEX_FIRST_ITEM, lunchWithAlice, TYPICAL_DATE_2,
+                        TYPICAL_DURATION_ONE_HOUR));
 
         // different duration -> returns false
         assertNotEquals(addLunchAliceMeetingCommand,
-                new AddCommand(INDEX_FIRST_ITEM, "Lunch with Alice", TYPICAL_DATE_1, TYPICAL_DURATION_HALF_HOUR));
+                new AddCommand(INDEX_FIRST_ITEM, lunchWithAlice, TYPICAL_DATE_1,
+                        TYPICAL_DURATION_HALF_HOUR));
     }
 
     /**

--- a/src/test/java/seedu/address/logic/commands/reminder/AddCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/reminder/AddCommandTest.java
@@ -17,6 +17,7 @@ import org.junit.jupiter.api.Test;
 
 import seedu.address.logic.commands.CommandResult;
 import seedu.address.logic.commands.exceptions.CommandException;
+import seedu.address.model.Message;
 import seedu.address.model.ModelStub;
 import seedu.address.model.ModelStubWithSortedPersonList;
 import seedu.address.model.person.Person;
@@ -24,7 +25,7 @@ import seedu.address.model.reminder.Reminder;
 import seedu.address.testutil.person.PersonBuilder;
 
 public class AddCommandTest {
-    private static final String MESSAGE = "message";
+    private static final Message MESSAGE = new Message("message");
 
     @Test
     public void constructor_nullIndex_throwsNullPointerException() {
@@ -70,13 +71,15 @@ public class AddCommandTest {
 
     @Test
     public void equals() {
-        AddCommand addCallAliceReminderCommand = new AddCommand(INDEX_FIRST_ITEM, "Call Alice", TYPICAL_DATE_1);
+        AddCommand addCallAliceReminderCommand =
+                new AddCommand(INDEX_FIRST_ITEM, new Message("Call Alice"), TYPICAL_DATE_1);
 
         // same object -> returns true
         assertEquals(addCallAliceReminderCommand, addCallAliceReminderCommand);
 
         // same values -> returns true
-        AddCommand addCallAliceReminderCommandCopy = new AddCommand(INDEX_FIRST_ITEM, "Call Alice", TYPICAL_DATE_1);
+        AddCommand addCallAliceReminderCommandCopy =
+                new AddCommand(INDEX_FIRST_ITEM, new Message("Call Alice"), TYPICAL_DATE_1);
         assertEquals(addCallAliceReminderCommand, addCallAliceReminderCommandCopy);
 
         // different types -> returns false
@@ -86,14 +89,16 @@ public class AddCommandTest {
         assertNotEquals(addCallAliceReminderCommand, null);
 
         // different index -> returns false
-        assertNotEquals(addCallAliceReminderCommand, new AddCommand(INDEX_SECOND_ITEM, "Call Alice",
+        assertNotEquals(addCallAliceReminderCommand, new AddCommand(INDEX_SECOND_ITEM, new Message("Call Alice"),
                 TYPICAL_DATE_1));
 
         // different message -> returns false
-        assertNotEquals(addCallAliceReminderCommand, new AddCommand(INDEX_FIRST_ITEM, "Call Bob", TYPICAL_DATE_1));
+        assertNotEquals(addCallAliceReminderCommand, new AddCommand(INDEX_FIRST_ITEM, new Message("Call Bob"),
+                TYPICAL_DATE_1));
 
         // different date -> returns false
-        assertNotEquals(addCallAliceReminderCommand, new AddCommand(INDEX_FIRST_ITEM, "Call Alice", TYPICAL_DATE_2));
+        assertNotEquals(addCallAliceReminderCommand, new AddCommand(INDEX_FIRST_ITEM, new Message("Call Alice"),
+                TYPICAL_DATE_2));
     }
 
     /**

--- a/src/test/java/seedu/address/logic/commands/reminder/AddCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/reminder/AddCommandTest.java
@@ -71,15 +71,16 @@ public class AddCommandTest {
 
     @Test
     public void equals() {
+        Message callAlice = new Message("Call Alice");
         AddCommand addCallAliceReminderCommand =
-                new AddCommand(INDEX_FIRST_ITEM, new Message("Call Alice"), TYPICAL_DATE_1);
+                new AddCommand(INDEX_FIRST_ITEM, callAlice, TYPICAL_DATE_1);
 
         // same object -> returns true
         assertEquals(addCallAliceReminderCommand, addCallAliceReminderCommand);
 
         // same values -> returns true
         AddCommand addCallAliceReminderCommandCopy =
-                new AddCommand(INDEX_FIRST_ITEM, new Message("Call Alice"), TYPICAL_DATE_1);
+                new AddCommand(INDEX_FIRST_ITEM, callAlice, TYPICAL_DATE_1);
         assertEquals(addCallAliceReminderCommand, addCallAliceReminderCommandCopy);
 
         // different types -> returns false
@@ -89,7 +90,7 @@ public class AddCommandTest {
         assertNotEquals(addCallAliceReminderCommand, null);
 
         // different index -> returns false
-        assertNotEquals(addCallAliceReminderCommand, new AddCommand(INDEX_SECOND_ITEM, new Message("Call Alice"),
+        assertNotEquals(addCallAliceReminderCommand, new AddCommand(INDEX_SECOND_ITEM, callAlice,
                 TYPICAL_DATE_1));
 
         // different message -> returns false
@@ -97,7 +98,7 @@ public class AddCommandTest {
                 TYPICAL_DATE_1));
 
         // different date -> returns false
-        assertNotEquals(addCallAliceReminderCommand, new AddCommand(INDEX_FIRST_ITEM, new Message("Call Alice"),
+        assertNotEquals(addCallAliceReminderCommand, new AddCommand(INDEX_FIRST_ITEM, callAlice,
                 TYPICAL_DATE_2));
     }
 

--- a/src/test/java/seedu/address/logic/commands/reminder/EditCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/reminder/EditCommandTest.java
@@ -2,7 +2,6 @@ package seedu.address.logic.commands.reminder;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static seedu.address.logic.commands.CommandTestUtil.MESSAGE_CALL_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_MESSAGE_CALL_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_MESSAGE_CALL_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandFailure;
@@ -19,6 +18,7 @@ import seedu.address.commons.core.index.Index;
 import seedu.address.logic.commands.PurgeCommand;
 import seedu.address.logic.commands.reminder.EditCommand.EditReminderDescriptor;
 import seedu.address.model.AddressBook;
+import seedu.address.model.Message;
 import seedu.address.model.Model;
 import seedu.address.model.ModelManager;
 import seedu.address.model.UserPrefs;
@@ -35,7 +35,8 @@ public class EditCommandTest {
 
     @Test
     public void execute_allFieldsSpecifiedUnfilteredList_success() {
-        Reminder editedReminder = new Reminder(GEORGE, VALID_MESSAGE_CALL_AMY, TypicalDates.TYPICAL_DATE_1);
+        Reminder editedReminder = new Reminder(GEORGE, new Message(VALID_MESSAGE_CALL_AMY),
+                TypicalDates.TYPICAL_DATE_1);
         EditReminderDescriptor descriptor = new EditReminderDescriptorBuilder()
                 // George appears as the 6th item
                 .withContactIndex(Index.fromZeroBased(6))
@@ -91,7 +92,7 @@ public class EditCommandTest {
         EditReminderDescriptor descriptor = new EditReminderDescriptorBuilder()
                 .withContactIndex(Index.fromZeroBased(model.getSortedPersonList().indexOf(firstReminder.getPerson())))
                 .withScheduledDate(firstReminder.getScheduledDate())
-                .withMessage(firstReminder.getMessage())
+                .withMessage(firstReminder.getMessage().message)
                 .build();
         EditCommand editCommand = new EditCommand(INDEX_SECOND_ITEM, descriptor);
 
@@ -112,7 +113,7 @@ public class EditCommandTest {
     public void equals() {
         EditReminderDescriptor descriptor =
                 new EditReminderDescriptorBuilder()
-                        .withMessage(MESSAGE_CALL_AMY)
+                        .withMessage(VALID_MESSAGE_CALL_AMY)
                         .withContactIndex(INDEX_SECOND_ITEM)
                         .withScheduledDate(TypicalDates.TYPICAL_DATE_3).build();
         final EditCommand standardCommand = new EditCommand(INDEX_FIRST_ITEM, descriptor);

--- a/src/test/java/seedu/address/logic/commands/reminder/EditCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/reminder/EditCommandTest.java
@@ -1,0 +1,144 @@
+package seedu.address.logic.commands.reminder;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.address.logic.commands.CommandTestUtil.MESSAGE_CALL_AMY;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_MESSAGE_CALL_AMY;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_MESSAGE_CALL_BOB;
+import static seedu.address.logic.commands.CommandTestUtil.assertCommandFailure;
+import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
+import static seedu.address.testutil.TypicalAddressBook.getTypicalAddressBookInReverse;
+import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_ITEM;
+import static seedu.address.testutil.TypicalIndexes.INDEX_SECOND_ITEM;
+import static seedu.address.testutil.person.TypicalPersons.GEORGE;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.commons.core.Messages;
+import seedu.address.commons.core.index.Index;
+import seedu.address.logic.commands.PurgeCommand;
+import seedu.address.logic.commands.reminder.EditCommand.EditReminderDescriptor;
+import seedu.address.model.AddressBook;
+import seedu.address.model.Model;
+import seedu.address.model.ModelManager;
+import seedu.address.model.UserPrefs;
+import seedu.address.model.reminder.Reminder;
+import seedu.address.testutil.TypicalDates;
+import seedu.address.testutil.reminder.EditReminderDescriptorBuilder;
+
+/**
+ * Contains integration tests (interaction with the Model, UndoCommand and RedoCommand) and unit tests for EditCommand.
+ */
+public class EditCommandTest {
+
+    private Model model = new ModelManager(getTypicalAddressBookInReverse(), new UserPrefs());
+
+    @Test
+    public void execute_allFieldsSpecifiedUnfilteredList_success() {
+        Reminder editedReminder = new Reminder(GEORGE, VALID_MESSAGE_CALL_AMY, TypicalDates.TYPICAL_DATE_1);
+        EditReminderDescriptor descriptor = new EditReminderDescriptorBuilder()
+                // George appears as the 6th item
+                .withContactIndex(Index.fromZeroBased(6))
+                .withMessage(VALID_MESSAGE_CALL_AMY)
+                .withScheduledDate(TypicalDates.TYPICAL_DATE_1)
+                .build();
+        EditCommand editCommand = new EditCommand(INDEX_FIRST_ITEM, descriptor);
+
+        String expectedMessage = String.format(EditCommand.MESSAGE_EDIT_REMINDER_SUCCESS, editedReminder);
+
+        Model expectedModel = new ModelManager(new AddressBook(model.getAddressBook()), new UserPrefs());
+        expectedModel.setReminder(model.getSortedReminderList().get(0), editedReminder);
+
+        assertCommandSuccess(editCommand, model, expectedMessage, expectedModel);
+    }
+
+    @Test
+    public void execute_someFieldsSpecifiedUnfilteredList_success() {
+        Index indexLastReminder = Index.fromOneBased(model.getSortedReminderList().size());
+        Reminder lastReminder = model.getSortedReminderList().get(indexLastReminder.getZeroBased());
+
+        Reminder editedReminder =
+                new Reminder(lastReminder.getPerson(), lastReminder.getMessage(), TypicalDates.TYPICAL_DATE_3);
+
+        EditReminderDescriptor descriptor =
+                new EditReminderDescriptorBuilder().withScheduledDate(TypicalDates.TYPICAL_DATE_3).build();
+
+        EditCommand editCommand = new EditCommand(indexLastReminder, descriptor);
+
+        String expectedMessage = String.format(EditCommand.MESSAGE_EDIT_REMINDER_SUCCESS, editedReminder);
+
+        Model expectedModel = new ModelManager(new AddressBook(model.getAddressBook()), new UserPrefs());
+        expectedModel.setReminder(lastReminder, editedReminder);
+
+        assertCommandSuccess(editCommand, model, expectedMessage, expectedModel);
+    }
+
+    @Test
+    public void execute_noFieldSpecifiedUnfilteredList_success() {
+        EditCommand editCommand = new EditCommand(INDEX_FIRST_ITEM, new EditReminderDescriptor());
+        Reminder editedReminder = model.getSortedReminderList().get(INDEX_FIRST_ITEM.getZeroBased());
+
+        String expectedMessage = String.format(EditCommand.MESSAGE_EDIT_REMINDER_SUCCESS, editedReminder);
+
+        Model expectedModel = new ModelManager(new AddressBook(model.getAddressBook()), new UserPrefs());
+
+        assertCommandSuccess(editCommand, model, expectedMessage, expectedModel);
+    }
+
+    @Test
+    public void execute_duplicateReminderUnfilteredList_failure() {
+        Reminder firstReminder = model.getSortedReminderList().get(INDEX_FIRST_ITEM.getZeroBased());
+        EditReminderDescriptor descriptor = new EditReminderDescriptorBuilder()
+                .withContactIndex(Index.fromZeroBased(model.getSortedPersonList().indexOf(firstReminder.getPerson())))
+                .withScheduledDate(firstReminder.getScheduledDate())
+                .withMessage(firstReminder.getMessage())
+                .build();
+        EditCommand editCommand = new EditCommand(INDEX_SECOND_ITEM, descriptor);
+
+        assertCommandFailure(editCommand, model, EditCommand.MESSAGE_DUPLICATE_REMINDER);
+    }
+
+    @Test
+    public void execute_invalidReminderIndexUnfilteredList_failure() {
+        Index outOfBoundIndex = Index.fromOneBased(model.getSortedReminderList().size() + 1);
+        EditReminderDescriptor descriptor =
+                new EditReminderDescriptorBuilder().withMessage(VALID_MESSAGE_CALL_BOB).build();
+        EditCommand editCommand = new EditCommand(outOfBoundIndex, descriptor);
+
+        assertCommandFailure(editCommand, model, Messages.MESSAGE_INVALID_REMINDER_DISPLAYED_INDEX);
+    }
+
+    @Test
+    public void equals() {
+        EditReminderDescriptor descriptor =
+                new EditReminderDescriptorBuilder()
+                        .withMessage(MESSAGE_CALL_AMY)
+                        .withContactIndex(INDEX_SECOND_ITEM)
+                        .withScheduledDate(TypicalDates.TYPICAL_DATE_3).build();
+        final EditCommand standardCommand = new EditCommand(INDEX_FIRST_ITEM, descriptor);
+
+        // same values -> returns true
+        EditReminderDescriptor copyDescriptor = new EditReminderDescriptor(descriptor);
+        EditCommand commandWithSameValues = new EditCommand(INDEX_FIRST_ITEM, copyDescriptor);
+        assertTrue(standardCommand.equals(commandWithSameValues));
+
+        // same object -> returns true
+        assertTrue(standardCommand.equals(standardCommand));
+
+        // null -> returns false
+        assertFalse(standardCommand.equals(null));
+
+        // different types -> returns false
+        assertFalse(standardCommand.equals(new PurgeCommand()));
+
+        // different index -> returns false
+        assertFalse(standardCommand.equals(new EditCommand(INDEX_SECOND_ITEM, descriptor)));
+
+        // different descriptor -> returns false
+        EditReminderDescriptor diffDescriptor =
+                new EditReminderDescriptorBuilder()
+                        .withScheduledDate(TypicalDates.TYPICAL_DATE_2)
+                        .build();
+        assertFalse(standardCommand.equals(new EditCommand(INDEX_FIRST_ITEM, diffDescriptor)));
+    }
+}

--- a/src/test/java/seedu/address/logic/commands/reminder/EditReminderDescriptorTest.java
+++ b/src/test/java/seedu/address/logic/commands/reminder/EditReminderDescriptorTest.java
@@ -1,0 +1,40 @@
+package seedu.address.logic.commands.reminder;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.address.testutil.TypicalIndexes.INDEX_SECOND_ITEM;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.logic.commands.reminder.EditCommand.EditReminderDescriptor;
+import seedu.address.testutil.TypicalDates;
+import seedu.address.testutil.reminder.EditReminderDescriptorBuilder;
+
+public class EditReminderDescriptorTest {
+
+    @Test
+    public void equals() {
+        EditReminderDescriptor descriptor =
+                new EditReminderDescriptorBuilder().withContactIndex(INDEX_SECOND_ITEM).build();
+        EditReminderDescriptor descriptorWithSameValues =
+                new EditReminderDescriptorBuilder().withContactIndex(INDEX_SECOND_ITEM).build();
+        EditReminderDescriptor descriptorWithDiffValues =
+                new EditReminderDescriptorBuilder().withContactIndex(INDEX_SECOND_ITEM)
+                        .withScheduledDate(TypicalDates.TYPICAL_DATE_2).build();
+
+        // same values -> returns true
+        assertTrue(descriptor.equals(descriptorWithSameValues));
+
+        // same object -> returns true
+        assertTrue(descriptor.equals(descriptor));
+
+        // null -> returns false
+        assertFalse(descriptor.equals(null));
+
+        // different types -> returns false
+        assertFalse(descriptor.equals(5));
+
+        // different values -> returns false
+        assertFalse(descriptor.equals(descriptorWithDiffValues));
+    }
+}

--- a/src/test/java/seedu/address/logic/parser/ParserUtilTest.java
+++ b/src/test/java/seedu/address/logic/parser/ParserUtilTest.java
@@ -16,6 +16,7 @@ import java.util.Set;
 import org.junit.jupiter.api.Test;
 
 import seedu.address.logic.parser.exceptions.ParseException;
+import seedu.address.model.Message;
 import seedu.address.model.person.Address;
 import seedu.address.model.person.Email;
 import seedu.address.model.person.Name;
@@ -211,6 +212,29 @@ public class ParserUtilTest {
         Set<Tag> expectedTagSet = new HashSet<Tag>(Arrays.asList(new Tag(VALID_TAG_1), new Tag(VALID_TAG_2)));
 
         assertEquals(expectedTagSet, actualTagSet);
+    }
+
+    @Test
+    public void parseMessage_null_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> ParserUtil.parseMessage(null));
+    }
+
+    @Test
+    public void parseMessage_invalidValue_throwsParseException() {
+        assertThrows(ParseException.class, () -> ParserUtil.parseMessage(INVALID_NAME));
+    }
+
+    @Test
+    public void parseMessage_validValueWithoutWhitespace_returnsName() throws Exception {
+        Message expectedMessage = new Message(VALID_NAME);
+        assertEquals(expectedMessage, ParserUtil.parseMessage(VALID_NAME));
+    }
+
+    @Test
+    public void parseMessage_validValueWithWhitespace_returnsTrimmedName() throws Exception {
+        String messageWithWhiteSpace = WHITESPACE + VALID_NAME + WHITESPACE;
+        Message expectedMessage = new Message(VALID_NAME);
+        assertEquals(expectedMessage, ParserUtil.parseMessage(messageWithWhiteSpace));
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/parser/meeting/AddCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/meeting/AddCommandParserTest.java
@@ -23,6 +23,7 @@ import static seedu.address.testutil.TypicalIndexes.INDEX_SECOND_ITEM;
 import org.junit.jupiter.api.Test;
 
 import seedu.address.logic.commands.meeting.AddCommand;
+import seedu.address.model.Message;
 
 public class AddCommandParserTest {
     private AddCommandParser parser = new AddCommandParser();
@@ -32,7 +33,8 @@ public class AddCommandParserTest {
         String userInput = CONTACT_INDEX_SECOND + MESSAGE_CALL_AMY + DATE_1 + DURATION_ONE_HOUR;
 
         AddCommand expectedCommand =
-                new AddCommand(INDEX_SECOND_ITEM, VALID_MESSAGE_CALL_AMY, TYPICAL_DATE_1, TYPICAL_DURATION_ONE_HOUR);
+                new AddCommand(INDEX_SECOND_ITEM, new Message(VALID_MESSAGE_CALL_AMY), TYPICAL_DATE_1,
+                        TYPICAL_DURATION_ONE_HOUR);
 
         assertParseSuccess(parser, userInput, expectedCommand);
     }

--- a/src/test/java/seedu/address/logic/parser/meeting/AddCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/meeting/AddCommandParserTest.java
@@ -80,14 +80,14 @@ public class AddCommandParserTest {
 
         // invalid message
         assertParseFailure(parser, INVALID_CONTACT_INDEX + " " + PREFIX_MESSAGE + "" + DATE_1,
-                String.format(MESSAGE_INVALID_COMMAND_FORMAT,
-                        seedu.address.logic.commands.reminder.AddCommand.MESSAGE_USAGE));
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddCommand.MESSAGE_USAGE));
 
         // invalid date
         assertParseFailure(parser,
                 CONTACT_INDEX_SECOND + MESSAGE_CALL_AMY + INVALID_DATE + DURATION_ONE_HOUR,
                 MESSAGE_INVALID_DATETIME);
-        assertParseFailure(parser, CONTACT_INDEX_SECOND + MESSAGE_CALL_AMY + " " + PREFIX_DATETIME + "",
+        assertParseFailure(parser,
+                CONTACT_INDEX_SECOND + MESSAGE_CALL_AMY + " " + PREFIX_DATETIME + "" + DURATION_ONE_HOUR,
                 MESSAGE_INVALID_DATETIME);
 
         // invalid duration

--- a/src/test/java/seedu/address/logic/parser/meeting/AddCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/meeting/AddCommandParserTest.java
@@ -14,6 +14,8 @@ import static seedu.address.logic.commands.CommandTestUtil.PREAMBLE_NON_EMPTY;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_DATE_1;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_DURATION_ONE_HOUR;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_MESSAGE_CALL_AMY;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_DATETIME;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_MESSAGE;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
 import static seedu.address.testutil.TypicalDates.TYPICAL_DATE_1;
@@ -76,9 +78,16 @@ public class AddCommandParserTest {
                 INVALID_CONTACT_INDEX + MESSAGE_CALL_AMY + DATE_1 + DURATION_ONE_HOUR,
                 String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddCommand.MESSAGE_USAGE));
 
+        // invalid message
+        assertParseFailure(parser, INVALID_CONTACT_INDEX + " " + PREFIX_MESSAGE + "" + DATE_1,
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+                        seedu.address.logic.commands.reminder.AddCommand.MESSAGE_USAGE));
+
         // invalid date
         assertParseFailure(parser,
                 CONTACT_INDEX_SECOND + MESSAGE_CALL_AMY + INVALID_DATE + DURATION_ONE_HOUR,
+                MESSAGE_INVALID_DATETIME);
+        assertParseFailure(parser, CONTACT_INDEX_SECOND + MESSAGE_CALL_AMY + " " + PREFIX_DATETIME + "",
                 MESSAGE_INVALID_DATETIME);
 
         // invalid duration

--- a/src/test/java/seedu/address/logic/parser/reminder/AddCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/reminder/AddCommandParserTest.java
@@ -10,6 +10,8 @@ import static seedu.address.logic.commands.CommandTestUtil.MESSAGE_CALL_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.PREAMBLE_NON_EMPTY;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_DATE_1;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_MESSAGE_CALL_AMY;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_DATETIME;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_MESSAGE;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
 import static seedu.address.testutil.TypicalDates.TYPICAL_DATE_1;
@@ -61,8 +63,14 @@ public class AddCommandParserTest {
         assertParseFailure(parser, INVALID_CONTACT_INDEX + MESSAGE_CALL_AMY + DATE_1,
                 String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddCommand.MESSAGE_USAGE));
 
+        // invalid message
+        assertParseFailure(parser, INVALID_CONTACT_INDEX + " " + PREFIX_MESSAGE + "" + DATE_1,
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddCommand.MESSAGE_USAGE));
+
         // invalid date
         assertParseFailure(parser, CONTACT_INDEX_SECOND + MESSAGE_CALL_AMY + INVALID_DATE,
+                MESSAGE_INVALID_DATETIME);
+        assertParseFailure(parser, CONTACT_INDEX_SECOND + MESSAGE_CALL_AMY + " " + PREFIX_DATETIME + "",
                 MESSAGE_INVALID_DATETIME);
 
         // non-empty preamble

--- a/src/test/java/seedu/address/logic/parser/reminder/AddCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/reminder/AddCommandParserTest.java
@@ -18,6 +18,7 @@ import static seedu.address.testutil.TypicalIndexes.INDEX_SECOND_ITEM;
 import org.junit.jupiter.api.Test;
 
 import seedu.address.logic.commands.reminder.AddCommand;
+import seedu.address.model.Message;
 
 public class AddCommandParserTest {
     private AddCommandParser parser = new AddCommandParser();
@@ -26,7 +27,8 @@ public class AddCommandParserTest {
     public void parse_allFieldsSpecified_success() {
         String userInput = CONTACT_INDEX_SECOND + MESSAGE_CALL_AMY + DATE_1;
 
-        AddCommand expectedCommand = new AddCommand(INDEX_SECOND_ITEM, VALID_MESSAGE_CALL_AMY, TYPICAL_DATE_1);
+        AddCommand expectedCommand = new AddCommand(INDEX_SECOND_ITEM, new Message(VALID_MESSAGE_CALL_AMY),
+                TYPICAL_DATE_1);
 
         assertParseSuccess(parser, userInput, expectedCommand);
     }

--- a/src/test/java/seedu/address/logic/parser/reminder/EditCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/reminder/EditCommandParserTest.java
@@ -12,6 +12,8 @@ import static seedu.address.logic.commands.CommandTestUtil.MESSAGE_CALL_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.MESSAGE_CALL_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_MESSAGE_CALL_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_MESSAGE_CALL_BOB;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_DATETIME;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_MESSAGE;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
 import static seedu.address.logic.parser.ParserUtil.MESSAGE_INVALID_INDEX;
@@ -24,6 +26,7 @@ import org.junit.jupiter.api.Test;
 import seedu.address.commons.core.index.Index;
 import seedu.address.logic.commands.reminder.EditCommand;
 import seedu.address.logic.commands.reminder.EditCommand.EditReminderDescriptor;
+import seedu.address.model.Message;
 import seedu.address.testutil.TypicalDates;
 import seedu.address.testutil.reminder.EditReminderDescriptorBuilder;
 
@@ -64,7 +67,10 @@ public class EditCommandParserTest {
     @Test
     public void parse_invalidValue_failure() {
         assertParseFailure(parser, "1" + INVALID_CONTACT_INDEX, MESSAGE_INVALID_INDEX); // invalid contact index
+        assertParseFailure(parser, "1" + " " + PREFIX_MESSAGE + "",
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, Message.MESSAGE_CONSTRAINTS));
         assertParseFailure(parser, "1" + INVALID_DATE, MESSAGE_INVALID_DATETIME); // invalid date
+        assertParseFailure(parser, "1" + CONTACT_INDEX_SECOND + " " + PREFIX_DATETIME + "", MESSAGE_INVALID_DATETIME);
 
         // multiple invalid values, but only the first invalid value is captured
         assertParseFailure(parser, "1" + INVALID_CONTACT_INDEX + INVALID_DATE + MESSAGE_CALL_AMY,

--- a/src/test/java/seedu/address/logic/parser/reminder/EditCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/reminder/EditCommandParserTest.java
@@ -1,0 +1,181 @@
+package seedu.address.logic.parser.reminder;
+
+import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.commons.core.Messages.MESSAGE_INVALID_DATETIME;
+import static seedu.address.logic.commands.CommandTestUtil.CONTACT_INDEX_SECOND;
+import static seedu.address.logic.commands.CommandTestUtil.CONTACT_INDEX_THIRD;
+import static seedu.address.logic.commands.CommandTestUtil.DATE_1;
+import static seedu.address.logic.commands.CommandTestUtil.DATE_2;
+import static seedu.address.logic.commands.CommandTestUtil.INVALID_CONTACT_INDEX;
+import static seedu.address.logic.commands.CommandTestUtil.INVALID_DATE;
+import static seedu.address.logic.commands.CommandTestUtil.MESSAGE_CALL_AMY;
+import static seedu.address.logic.commands.CommandTestUtil.MESSAGE_CALL_BOB;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_MESSAGE_CALL_AMY;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_MESSAGE_CALL_BOB;
+import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
+import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
+import static seedu.address.logic.parser.ParserUtil.MESSAGE_INVALID_INDEX;
+import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_ITEM;
+import static seedu.address.testutil.TypicalIndexes.INDEX_SECOND_ITEM;
+import static seedu.address.testutil.TypicalIndexes.INDEX_THIRD_ITEM;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.commons.core.index.Index;
+import seedu.address.logic.commands.reminder.EditCommand;
+import seedu.address.logic.commands.reminder.EditCommand.EditReminderDescriptor;
+import seedu.address.testutil.TypicalDates;
+import seedu.address.testutil.reminder.EditReminderDescriptorBuilder;
+
+public class EditCommandParserTest {
+
+    private static final String MESSAGE_INVALID_FORMAT =
+            String.format(MESSAGE_INVALID_COMMAND_FORMAT, EditCommand.MESSAGE_USAGE);
+
+    private EditCommandParser parser = new EditCommandParser();
+
+    @Test
+    public void parse_missingParts_failure() {
+        // no index specified
+        assertParseFailure(parser, DATE_1, MESSAGE_INVALID_FORMAT);
+
+        // no field specified
+        assertParseFailure(parser, "1", EditCommand.MESSAGE_NOT_EDITED);
+
+        // no index and no field specified
+        assertParseFailure(parser, "", MESSAGE_INVALID_FORMAT);
+    }
+
+    @Test
+    public void parse_invalidPreamble_failure() {
+        // negative index
+        assertParseFailure(parser, "-5" + DATE_1, MESSAGE_INVALID_FORMAT);
+
+        // zero index
+        assertParseFailure(parser, "0" + DATE_1, MESSAGE_INVALID_FORMAT);
+
+        // invalid arguments being parsed as preamble
+        assertParseFailure(parser, "1 some random string", MESSAGE_INVALID_FORMAT);
+
+        // invalid prefix being parsed as preamble
+        assertParseFailure(parser, "1 i/ string", MESSAGE_INVALID_FORMAT);
+    }
+
+    @Test
+    public void parse_invalidValue_failure() {
+        assertParseFailure(parser, "1" + INVALID_CONTACT_INDEX, MESSAGE_INVALID_INDEX); // invalid contact index
+        assertParseFailure(parser, "1" + INVALID_DATE, MESSAGE_INVALID_DATETIME); // invalid date
+
+        // multiple invalid values, but only the first invalid value is captured
+        assertParseFailure(parser, "1" + INVALID_CONTACT_INDEX + INVALID_DATE + MESSAGE_CALL_AMY,
+                MESSAGE_INVALID_INDEX);
+    }
+
+    @Test
+    public void parse_allFieldsSpecified_success() {
+        Index targetIndex = INDEX_SECOND_ITEM;
+        String userInput =
+                targetIndex.getOneBased() + CONTACT_INDEX_SECOND + DATE_1 + MESSAGE_CALL_AMY;
+
+        EditReminderDescriptor descriptor =
+                new EditReminderDescriptorBuilder()
+                        .withContactIndex(INDEX_SECOND_ITEM)
+                        .withScheduledDate(TypicalDates.TYPICAL_DATE_1)
+                        .withMessage(VALID_MESSAGE_CALL_AMY)
+                        .build();
+
+        EditCommand expectedCommand = new EditCommand(targetIndex, descriptor);
+
+        assertParseSuccess(parser, userInput, expectedCommand);
+    }
+
+    @Test
+    public void parse_someFieldsSpecified_success() {
+        Index targetIndex = INDEX_SECOND_ITEM;
+        String userInput =
+                targetIndex.getOneBased() + DATE_1 + MESSAGE_CALL_AMY;
+
+        EditReminderDescriptor descriptor =
+                new EditReminderDescriptorBuilder()
+                        .withScheduledDate(TypicalDates.TYPICAL_DATE_1)
+                        .withMessage(VALID_MESSAGE_CALL_AMY)
+                        .build();
+
+        EditCommand expectedCommand = new EditCommand(targetIndex, descriptor);
+
+        assertParseSuccess(parser, userInput, expectedCommand);
+    }
+
+    @Test
+    public void parse_oneFieldSpecified_success() {
+        Index targetIndex = INDEX_THIRD_ITEM;
+
+        // contact index
+        String userInput = targetIndex.getOneBased() + CONTACT_INDEX_SECOND;
+        EditReminderDescriptor descriptor =
+                new EditReminderDescriptorBuilder()
+                        .withContactIndex(INDEX_SECOND_ITEM)
+                        .build();
+        EditCommand expectedCommand = new EditCommand(targetIndex, descriptor);
+        assertParseSuccess(parser, userInput, expectedCommand);
+
+        // message
+        userInput = targetIndex.getOneBased() + MESSAGE_CALL_AMY;
+        descriptor =
+                new EditReminderDescriptorBuilder()
+                        .withMessage(VALID_MESSAGE_CALL_AMY)
+                        .build();
+        expectedCommand = new EditCommand(targetIndex, descriptor);
+        assertParseSuccess(parser, userInput, expectedCommand);
+
+        // scheduledDate
+        userInput = targetIndex.getOneBased() + DATE_1;
+        descriptor =
+                new EditReminderDescriptorBuilder()
+                        .withScheduledDate(TypicalDates.TYPICAL_DATE_1)
+                        .build();
+        expectedCommand = new EditCommand(targetIndex, descriptor);
+        assertParseSuccess(parser, userInput, expectedCommand);
+    }
+
+    @Test
+    public void parse_multipleRepeatedFields_acceptsLast() {
+        Index targetIndex = INDEX_FIRST_ITEM;
+        String userInput = targetIndex.getOneBased() + MESSAGE_CALL_AMY + CONTACT_INDEX_SECOND + MESSAGE_CALL_BOB
+                + CONTACT_INDEX_THIRD + DATE_1 + DATE_2;
+
+        EditReminderDescriptor descriptor = new EditReminderDescriptorBuilder()
+                .withContactIndex(INDEX_THIRD_ITEM)
+                .withMessage(VALID_MESSAGE_CALL_BOB)
+                .withScheduledDate(TypicalDates.TYPICAL_DATE_2)
+                .build();
+        EditCommand expectedCommand = new EditCommand(targetIndex, descriptor);
+
+        assertParseSuccess(parser, userInput, expectedCommand);
+    }
+
+    @Test
+    public void parse_invalidValueFollowedByValidValue_success() {
+        // no other valid values specified
+        Index targetIndex = INDEX_FIRST_ITEM;
+        String userInput = targetIndex.getOneBased() + INVALID_DATE + DATE_1;
+        EditReminderDescriptor descriptor =
+                new EditReminderDescriptorBuilder()
+                        .withScheduledDate(TypicalDates.TYPICAL_DATE_1)
+                        .build();
+        EditCommand expectedCommand = new EditCommand(targetIndex, descriptor);
+        assertParseSuccess(parser, userInput, expectedCommand);
+
+        // other valid values specified
+        userInput = targetIndex.getOneBased() + INVALID_DATE + DATE_1 + MESSAGE_CALL_AMY;
+        descriptor =
+                new EditReminderDescriptorBuilder()
+                        .withScheduledDate(TypicalDates.TYPICAL_DATE_1)
+                        .withMessage(VALID_MESSAGE_CALL_AMY)
+                        .build();
+
+        expectedCommand = new EditCommand(targetIndex, descriptor);
+        assertParseSuccess(parser, userInput, expectedCommand);
+    }
+
+}

--- a/src/test/java/seedu/address/logic/parser/reminder/EditCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/reminder/EditCommandParserTest.java
@@ -68,7 +68,7 @@ public class EditCommandParserTest {
     public void parse_invalidValue_failure() {
         assertParseFailure(parser, "1" + INVALID_CONTACT_INDEX, MESSAGE_INVALID_INDEX); // invalid contact index
         assertParseFailure(parser, "1" + " " + PREFIX_MESSAGE + "",
-                String.format(MESSAGE_INVALID_COMMAND_FORMAT, Message.MESSAGE_CONSTRAINTS));
+                Message.MESSAGE_CONSTRAINTS);
         assertParseFailure(parser, "1" + INVALID_DATE, MESSAGE_INVALID_DATETIME); // invalid date
         assertParseFailure(parser, "1" + CONTACT_INDEX_SECOND + " " + PREFIX_DATETIME + "", MESSAGE_INVALID_DATETIME);
 

--- a/src/test/java/seedu/address/model/MessageTest.java
+++ b/src/test/java/seedu/address/model/MessageTest.java
@@ -1,0 +1,46 @@
+package seedu.address.model;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.address.testutil.Assert.assertThrows;
+
+import org.junit.jupiter.api.Test;
+
+public class MessageTest {
+
+    @Test
+    public void constructor_null_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> new Message(null));
+    }
+
+    @Test
+    public void constructor_invalidMessage_throwsIllegalArgumentException() {
+        String invalidMessage = "";
+        assertThrows(IllegalArgumentException.class, () -> new Message(invalidMessage));
+    }
+
+    @Test
+    public void isValidMessage() {
+        // null message
+        assertThrows(NullPointerException.class, () -> Message.isValidMessage(null));
+
+        // invalid message
+        assertFalse(Message.isValidMessage("")); // empty string
+        assertFalse(Message.isValidMessage(" ")); // spaces only
+        assertFalse(Message.isValidMessage("^")); // only non-alphanumeric characters
+        assertFalse(Message.isValidMessage("call peter*")); // contains non-alphanumeric characters
+
+        // valid name
+        assertTrue(Message.isValidMessage("peter jack")); // alphabets only
+        assertTrue(Message.isValidMessage("12345")); // numbers only
+        assertTrue(Message.isValidMessage("peter the 2nd")); // alphanumeric characters
+        assertTrue(Message.isValidMessage("Capital Tan")); // with capital letters
+        assertTrue(Message.isValidMessage("David Roger Jackson Ray Jr 2nd")); // long messages
+    }
+
+    @Test
+    public void equals() {
+        String msgWithMixedCase = "nLDSfdkfas";
+        assertTrue(new Message(msgWithMixedCase).equals(new Message(msgWithMixedCase.toLowerCase())));
+    }
+}

--- a/src/test/java/seedu/address/model/ModelManagerTest.java
+++ b/src/test/java/seedu/address/model/ModelManagerTest.java
@@ -223,6 +223,14 @@ public class ModelManagerTest {
     }
 
     @Test
+    public void setReminder_nullGiven_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> modelManager.setReminder(null, null));
+        assertThrows(NullPointerException.class, () -> modelManager.setReminder(null, CALL_ALICE));
+        assertThrows(NullPointerException.class, () -> modelManager.setReminder(CALL_ALICE, null));
+    }
+
+
+    @Test
     public void getSortedReminderList_reminderWithEarlierDateAdded_meetingInSortedOrder() {
         modelManager.addReminder(CALL_ALICE);
         modelManager.addReminder(EMAIL_BENSON);

--- a/src/test/java/seedu/address/model/meeting/MeetingTest.java
+++ b/src/test/java/seedu/address/model/meeting/MeetingTest.java
@@ -11,8 +11,10 @@ import java.time.LocalDateTime;
 
 import org.junit.jupiter.api.Test;
 
+import seedu.address.model.Message;
+
 public class MeetingTest {
-    private static final String VALID_MESSAGE = "Some dummy message";
+    private static final Message VALID_MESSAGE = new Message("Some dummy message");
     private static final LocalDateTime VALID_DATETIME = LocalDateTime.of(2020, 10, 30, 15, 19);
     private static final Duration VALID_DURATION = Duration.ofMinutes(30);
 
@@ -25,13 +27,6 @@ public class MeetingTest {
         assertThrows(NullPointerException.class, () -> new Meeting(null, VALID_MESSAGE, null, null));
         assertThrows(NullPointerException.class, () -> new Meeting(null, null, VALID_DATETIME, null));
         assertThrows(NullPointerException.class, () -> new Meeting(null, null, null, VALID_DURATION));
-    }
-
-    @Test
-    public void constructor_messageWithWhiteSpace_returnsMeetingWithWhiteSpaceStripped() {
-        String message = WHITESPACE + VALID_MESSAGE + WHITESPACE;
-        Meeting meeting = new Meeting(ALICE, message, VALID_DATETIME, VALID_DURATION);
-        assertEquals(meeting.getMessage(), VALID_MESSAGE);
     }
 
     @Test
@@ -50,7 +45,8 @@ public class MeetingTest {
     @Test
     public void equals_sameFieldsWithDifferentCasing_returnsTrue() {
         Meeting meeting1 = new Meeting(ALICE, VALID_MESSAGE, VALID_DATETIME, VALID_DURATION);
-        Meeting meeting2 = new Meeting(ALICE, VALID_MESSAGE.toLowerCase(), VALID_DATETIME, VALID_DURATION);
+        Meeting meeting2 = new Meeting(ALICE, new Message(VALID_MESSAGE.message.toLowerCase()), VALID_DATETIME,
+                VALID_DURATION);
         assertEquals(meeting1, meeting2);
     }
 

--- a/src/test/java/seedu/address/model/meeting/UniqueMeetingListTest.java
+++ b/src/test/java/seedu/address/model/meeting/UniqueMeetingListTest.java
@@ -16,6 +16,7 @@ import java.util.List;
 
 import org.junit.jupiter.api.Test;
 
+import seedu.address.model.Message;
 import seedu.address.model.meeting.exceptions.DuplicateMeetingException;
 import seedu.address.model.meeting.exceptions.MeetingNotFoundException;
 
@@ -84,7 +85,7 @@ public class UniqueMeetingListTest {
     public void removeMeetingsWithContact_contactWithMultipleMeetings_associatedMeetingsRemoved() {
         uniqueMeetingList.add(MEET_ALICE);
         uniqueMeetingList.add(PRESENT_PROPOSAL_BENSON);
-        uniqueMeetingList.add(new Meeting(ALICE, "Second meeting with Alice",
+        uniqueMeetingList.add(new Meeting(ALICE, new Message("Second meeting with Alice"),
                 LocalDateTime.of(2021, 10, 30, 10, 19),
                 Duration.ofMinutes(60)));
 

--- a/src/test/java/seedu/address/model/reminder/ReminderTest.java
+++ b/src/test/java/seedu/address/model/reminder/ReminderTest.java
@@ -10,9 +10,11 @@ import java.time.LocalDateTime;
 
 import org.junit.jupiter.api.Test;
 
+import seedu.address.model.Message;
+
 public class ReminderTest {
     private static final LocalDateTime VALID_DATETIME = LocalDateTime.of(2020, 10, 30, 15, 19);
-    private static final String VALID_MESSAGE = "Some dummy message";
+    private static final Message VALID_MESSAGE = new Message("Some dummy message");
 
     private static final String WHITESPACE = " \t\r\n";
 
@@ -25,13 +27,6 @@ public class ReminderTest {
         assertThrows(NullPointerException.class, () -> new Reminder(ALICE, VALID_MESSAGE, null));
         assertThrows(NullPointerException.class, () -> new Reminder(ALICE, null, VALID_DATETIME));
         assertThrows(NullPointerException.class, () -> new Reminder(null, VALID_MESSAGE, VALID_DATETIME));
-    }
-
-    @Test
-    public void constructor_messageWithWhiteSpace_returnsReminderWithWhiteSpaceStripped() {
-        String message = WHITESPACE + VALID_MESSAGE + WHITESPACE;
-        Reminder reminder = new Reminder(ALICE, message, VALID_DATETIME);
-        assertEquals(reminder.getMessage(), VALID_MESSAGE);
     }
 
     @Test
@@ -50,7 +45,7 @@ public class ReminderTest {
     @Test
     public void equals_sameFieldsWithDifferentCasing_returnsTrue() {
         Reminder reminder1 = new Reminder(ALICE, VALID_MESSAGE, VALID_DATETIME);
-        Reminder reminder2 = new Reminder(ALICE, VALID_MESSAGE.toLowerCase(), VALID_DATETIME);
+        Reminder reminder2 = new Reminder(ALICE, new Message(VALID_MESSAGE.message.toLowerCase()), VALID_DATETIME);
         assertEquals(reminder1, reminder2);
     }
 

--- a/src/test/java/seedu/address/model/reminder/UniqueReminderListTest.java
+++ b/src/test/java/seedu/address/model/reminder/UniqueReminderListTest.java
@@ -94,6 +94,51 @@ public class UniqueReminderListTest {
     }
 
     @Test
+    public void setReminder_nullTargetReminder_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> uniqueReminderList.setReminder(null, CALL_ALICE));
+    }
+
+    @Test
+    public void setReminder_nullEditedReminder_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> uniqueReminderList.setReminder(CALL_ALICE, null));
+    }
+
+    @Test
+    public void setReminder_targetReminderNotInList_throwsReminderNotFoundException() {
+        assertThrows(ReminderNotFoundException.class, () -> uniqueReminderList.setReminder(CALL_ALICE, CALL_ALICE));
+    }
+
+    @Test
+    public void setReminder_editedReminderIsSameReminder_success() {
+        uniqueReminderList.add(CALL_ALICE);
+        uniqueReminderList.setReminder(CALL_ALICE, CALL_ALICE);
+
+        UniqueReminderList expectedUniqueReminderList = new UniqueReminderList();
+        expectedUniqueReminderList.add(CALL_ALICE);
+
+        assertEquals(expectedUniqueReminderList, uniqueReminderList);
+    }
+
+    @Test
+    public void setReminder_editedReminderIsDifferent_success() {
+        uniqueReminderList.add(CALL_ALICE);
+        uniqueReminderList.setReminder(CALL_ALICE, EMAIL_BENSON);
+
+        UniqueReminderList expectedUniqueReminderList = new UniqueReminderList();
+        expectedUniqueReminderList.add(EMAIL_BENSON);
+
+        assertEquals(expectedUniqueReminderList, uniqueReminderList);
+    }
+
+    @Test
+    public void setReminder_editedReminderExists_throwsDuplicateReminderException() {
+        uniqueReminderList.add(CALL_ALICE);
+        uniqueReminderList.add(EMAIL_BENSON);
+
+        assertThrows(DuplicateReminderException.class, () -> uniqueReminderList.setReminder(CALL_ALICE, EMAIL_BENSON));
+    }
+
+    @Test
     public void setReminders_nullUniqueReminderList_throwsNullPointerException() {
         assertThrows(NullPointerException.class, () -> uniqueReminderList.setReminders((UniqueReminderList) null));
     }

--- a/src/test/java/seedu/address/model/reminder/UniqueReminderListTest.java
+++ b/src/test/java/seedu/address/model/reminder/UniqueReminderListTest.java
@@ -15,6 +15,7 @@ import java.util.List;
 
 import org.junit.jupiter.api.Test;
 
+import seedu.address.model.Message;
 import seedu.address.model.reminder.exceptions.DuplicateReminderException;
 import seedu.address.model.reminder.exceptions.ReminderNotFoundException;
 
@@ -82,7 +83,7 @@ public class UniqueReminderListTest {
     public void removeRemindersWithContact_contactWithMultipleReminders_associatedRemindersRemoved() {
         uniqueReminderList.add(CALL_ALICE);
         uniqueReminderList.add(EMAIL_BENSON);
-        uniqueReminderList.add(new Reminder(ALICE, "Second reminder with Alice",
+        uniqueReminderList.add(new Reminder(ALICE, new Message("Second reminder with Alice"),
                 LocalDateTime.of(2021, 10, 30, 10, 19)));
 
         uniqueReminderList.removeRemindersWithContact(ALICE);

--- a/src/test/java/seedu/address/testutil/TypicalDates.java
+++ b/src/test/java/seedu/address/testutil/TypicalDates.java
@@ -1,12 +1,19 @@
 package seedu.address.testutil;
 
+import static seedu.address.logic.commands.CommandTestUtil.VALID_DATE_1;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_DATE_2;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_DATE_3;
+
 import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
 
 /**
  * A utility class containing a list of {@code LocalDateTime} objects to be used in tests.
  */
 public class TypicalDates {
-    public static final LocalDateTime TYPICAL_DATE_1 = LocalDateTime.of(2020, 10, 30, 15, 19);
-    public static final LocalDateTime TYPICAL_DATE_2 = LocalDateTime.of(2018, 12, 20, 12, 0);
-    public static final LocalDateTime TYPICAL_DATE_3 = LocalDateTime.of(2020, 12, 20, 12, 12);
+    private static final DateTimeFormatter FORMATTER = DateTimeFormatter.ofPattern(("yyyy-MM-dd HH:mm"));
+
+    public static final LocalDateTime TYPICAL_DATE_1 = LocalDateTime.parse(VALID_DATE_1, FORMATTER);
+    public static final LocalDateTime TYPICAL_DATE_2 = LocalDateTime.parse(VALID_DATE_2, FORMATTER);
+    public static final LocalDateTime TYPICAL_DATE_3 = LocalDateTime.parse(VALID_DATE_3, FORMATTER);
 }

--- a/src/test/java/seedu/address/testutil/meeting/TypicalMeetings.java
+++ b/src/test/java/seedu/address/testutil/meeting/TypicalMeetings.java
@@ -10,6 +10,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
+import seedu.address.model.Message;
 import seedu.address.model.meeting.Meeting;
 
 /**
@@ -18,16 +19,16 @@ import seedu.address.model.meeting.Meeting;
 public class TypicalMeetings {
 
     public static final Meeting MEET_ALICE =
-        new Meeting(ALICE, "Meet Alice to discuss pricing", LocalDateTime.of(2020, 10, 30, 15, 19),
-            Duration.ofMinutes(60));
+            new Meeting(ALICE, new Message("Meet Alice to discuss pricing"), LocalDateTime.of(2020, 10, 30, 15, 19),
+                    Duration.ofMinutes(60));
 
     public static final Meeting PRESENT_PROPOSAL_BENSON =
-        new Meeting(BENSON, "Present proposal to Benson", LocalDateTime.of(2018, 12, 20, 12, 0),
-            Duration.ofMinutes(90));
+            new Meeting(BENSON, new Message("Present proposal to Benson"), LocalDateTime.of(2018, 12, 20, 12, 0),
+                    Duration.ofMinutes(90));
 
     public static final Meeting LUNCH_CARL =
-        new Meeting(CARL, "Lunch with Carl", LocalDateTime.of(2020, 12, 20, 12, 12),
-            Duration.ofMinutes(45));
+            new Meeting(CARL, new Message("Lunch with Carl"), LocalDateTime.of(2020, 12, 20, 12, 12),
+                    Duration.ofMinutes(45));
 
 
     private TypicalMeetings() {

--- a/src/test/java/seedu/address/testutil/reminder/EditReminderDescriptorBuilder.java
+++ b/src/test/java/seedu/address/testutil/reminder/EditReminderDescriptorBuilder.java
@@ -4,6 +4,7 @@ import java.time.LocalDateTime;
 
 import seedu.address.commons.core.index.Index;
 import seedu.address.logic.commands.reminder.EditCommand.EditReminderDescriptor;
+import seedu.address.model.Message;
 
 /**
  * A utility class to help with building EditReminderDescriptor objects.
@@ -32,7 +33,7 @@ public class EditReminderDescriptorBuilder {
      * Sets the {@code message} of the {@code EditReminderDescriptor} that we are building.
      */
     public EditReminderDescriptorBuilder withMessage(String message) {
-        descriptor.setMessage(message);
+        descriptor.setMessage(new Message(message));
         return this;
     }
 

--- a/src/test/java/seedu/address/testutil/reminder/EditReminderDescriptorBuilder.java
+++ b/src/test/java/seedu/address/testutil/reminder/EditReminderDescriptorBuilder.java
@@ -1,0 +1,51 @@
+package seedu.address.testutil.reminder;
+
+import java.time.LocalDateTime;
+
+import seedu.address.commons.core.index.Index;
+import seedu.address.logic.commands.reminder.EditCommand.EditReminderDescriptor;
+
+/**
+ * A utility class to help with building EditReminderDescriptor objects.
+ */
+public class EditReminderDescriptorBuilder {
+
+    private EditReminderDescriptor descriptor;
+
+    public EditReminderDescriptorBuilder() {
+        descriptor = new EditReminderDescriptor();
+    }
+
+    public EditReminderDescriptorBuilder(EditReminderDescriptor descriptor) {
+        this.descriptor = new EditReminderDescriptor(descriptor);
+    }
+
+    /**
+     * Sets the {@code contactIndex} of the {@code EditReminderDescriptor} that we are building.
+     */
+    public EditReminderDescriptorBuilder withContactIndex(Index contactIndex) {
+        descriptor.setContactIndex(contactIndex);
+        return this;
+    }
+
+    /**
+     * Sets the {@code message} of the {@code EditReminderDescriptor} that we are building.
+     */
+    public EditReminderDescriptorBuilder withMessage(String message) {
+        descriptor.setMessage(message);
+        return this;
+    }
+
+    /**
+     * Sets the {@code Email} of the {@code EditReminderDescriptor} that we are building.
+     */
+    public EditReminderDescriptorBuilder withScheduledDate(LocalDateTime scheduledDate) {
+        descriptor.setScheduledDate(scheduledDate);
+        return this;
+    }
+
+
+    public EditReminderDescriptor build() {
+        return descriptor;
+    }
+}

--- a/src/test/java/seedu/address/testutil/reminder/TypicalReminders.java
+++ b/src/test/java/seedu/address/testutil/reminder/TypicalReminders.java
@@ -9,6 +9,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
+import seedu.address.model.Message;
 import seedu.address.model.reminder.Reminder;
 
 /**
@@ -16,12 +17,12 @@ import seedu.address.model.reminder.Reminder;
  */
 public class TypicalReminders {
 
-    public static final Reminder CALL_ALICE = new Reminder(ALICE, "Call Alice",
-        LocalDateTime.of(2020, 10, 30, 15, 19));
-    public static final Reminder EMAIL_BENSON = new Reminder(BENSON, "Email Benson",
-        LocalDateTime.of(2018, 12, 20, 12, 0));
-    public static final Reminder SET_MEETING_CARL = new Reminder(CARL, "Set meeting with Carl",
-        LocalDateTime.of(2020, 12, 20, 12, 12));
+    public static final Reminder CALL_ALICE = new Reminder(ALICE, new Message("Call Alice"),
+            LocalDateTime.of(2020, 10, 30, 15, 19));
+    public static final Reminder EMAIL_BENSON = new Reminder(BENSON, new Message("Email Benson"),
+            LocalDateTime.of(2018, 12, 20, 12, 0));
+    public static final Reminder SET_MEETING_CARL = new Reminder(CARL, new Message("Set meeting with Carl"),
+            LocalDateTime.of(2020, 12, 20, 12, 12));
 
     // prevents instantiation
     private TypicalReminders() {


### PR DESCRIPTION
Based off `overdue-reminders` branch
- See diff at: https://github.com/sebastiantoh/tp/compare/overdue-reminders...sebastiantoh:update-reminders

Closes #112

Changes:
- Added `reminder edit` command.
  - Added relevant tests.
  - Updated user guide.
- Refactored `Meeting` and `Reminder` to contain `Message` class rather than a `String` for stronger input validation. `Meeting` and `Reminder` must now contain a non-empty alphanumeric string as its message. Previously, this was not enforced.

Demo of `reminder edit`:
![reminder edit](https://user-images.githubusercontent.com/24363622/96391672-25db1180-11ec-11eb-93ae-0b1a0b3a5b83.gif)
