### PR TITLE
Implement edit functionality for Sale

### DIFF
--- a/src/main/java/seedu/address/logic/commands/sale/EditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/sale/EditCommand.java
@@ -13,6 +13,7 @@ import java.time.LocalDateTime;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 
@@ -80,17 +81,19 @@ public class EditCommand extends Command {
             throw new CommandException(Messages.MESSAGE_INVALID_SALE_DISPLAYED_INDEX);
         }
 
+        Sale saleToEdit = lastShownList.get(saleIndex.getZeroBased());
+
         if(personIndex != null) {
             List<Person> lastShownPeople = model.getSortedPersonList();
             if (personIndex.getZeroBased() >= lastShownPeople.size()) {
                 throw new CommandException(Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
             }
-
             Person newBuyer = lastShownPeople.get(personIndex.getZeroBased());
             editSaleDescriptor.setBuyerId(newBuyer.getId());
+        } else {
+            editSaleDescriptor.setBuyerId(saleToEdit.getBuyerId());
         }
 
-        Sale saleToEdit = lastShownList.get(saleIndex.getZeroBased());
         Sale editedSale = createEditedSale(saleToEdit, editSaleDescriptor);
 
         if (!model.saleTagsExist(editedSale)) {
@@ -140,7 +143,8 @@ public class EditCommand extends Command {
         // state check
         EditCommand e = (EditCommand) other;
         return saleIndex.equals(e.saleIndex)
-                && editSaleDescriptor.equals(e.editSaleDescriptor);
+                && editSaleDescriptor.equals(e.editSaleDescriptor)
+                && (Objects.equals(personIndex, e.personIndex));
     }
 
     /**

--- a/src/main/java/seedu/address/logic/commands/sale/EditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/sale/EditCommand.java
@@ -83,7 +83,7 @@ public class EditCommand extends Command {
 
         Sale saleToEdit = lastShownList.get(saleIndex.getZeroBased());
 
-        if(personIndex != null) {
+        if (personIndex != null) {
             List<Person> lastShownPeople = model.getSortedPersonList();
             if (personIndex.getZeroBased() >= lastShownPeople.size()) {
                 throw new CommandException(Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);

--- a/src/main/java/seedu/address/logic/commands/sale/EditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/sale/EditCommand.java
@@ -1,0 +1,261 @@
+package seedu.address.logic.commands.sale;
+
+import static java.util.Objects.requireNonNull;
+import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_SALE_CONTACT_INDEX;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_SALE_DATE;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_SALE_NAME;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_SALE_QUANTITY;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_SALE_UNIT_PRICE;
+import static seedu.address.model.Model.PREDICATE_SHOW_ALL_SALES;
+
+import java.time.LocalDateTime;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+
+import seedu.address.commons.core.Messages;
+import seedu.address.commons.core.index.Index;
+import seedu.address.commons.util.CollectionUtil;
+import seedu.address.logic.commands.Command;
+import seedu.address.logic.commands.CommandResult;
+import seedu.address.logic.commands.exceptions.CommandException;
+import seedu.address.model.Model;
+import seedu.address.model.person.Person;
+import seedu.address.model.sale.ItemName;
+import seedu.address.model.sale.Quantity;
+import seedu.address.model.sale.Sale;
+import seedu.address.model.sale.UnitPrice;
+import seedu.address.model.tag.Tag;
+
+/**
+ * Edits the details of an existing sale in the address book.
+ */
+public class EditCommand extends Command {
+
+    public static final String COMMAND_WORD = "sale edit";
+
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Edits the details of the sale identified "
+            + "by the index number used in the displayed sale list. "
+            + "Existing values will be overwritten by the input values.\n"
+            + "Parameters: INDEX (must be a positive integer) "
+            + "[" + PREFIX_SALE_CONTACT_INDEX + "CONTACT_INDEX] "
+            + "[" + PREFIX_SALE_NAME + "ITEM_NAME] "
+            + "[" + PREFIX_SALE_DATE + "DATETIME_OF_PURCHASE] "
+            + "[" + PREFIX_SALE_UNIT_PRICE + "UNIT_PRICE] "
+            + "[" + PREFIX_SALE_QUANTITY + "QUANTITY]\n"
+            + "Example: " + COMMAND_WORD + " 3 "
+            + PREFIX_SALE_NAME + "File "
+            + PREFIX_SALE_QUANTITY + "25 ";
+
+    public static final String MESSAGE_EDIT_SALE_SUCCESS = "Edited Sale: %1$s";
+    public static final String MESSAGE_NOT_EDITED = "At least one field to edit must be provided.";
+    public static final String MESSAGE_DUPLICATE_SALE = "This sale already exists in the address book.";
+
+    private final Index saleIndex;
+    private final Index personIndex;
+    private final EditSaleDescriptor editSaleDescriptor;
+
+    /**
+     * Constructs a new EditCommand.
+     * @param saleIndex of the sale in the filtered sale list to edit
+     * @param editSaleDescriptor details to edit the sale with.
+     * @param personIndex of the person in the contact to assign as buyer.
+     */
+    public EditCommand(Index saleIndex, EditSaleDescriptor editSaleDescriptor, Index personIndex) {
+        requireAllNonNull(saleIndex, editSaleDescriptor);
+        this.saleIndex = saleIndex;
+        this.editSaleDescriptor = new EditSaleDescriptor(editSaleDescriptor);
+        this.personIndex = personIndex;
+    }
+
+    @Override
+    public CommandResult execute(Model model) throws CommandException {
+        requireNonNull(model);
+        List<Sale> lastShownList = model.getFilteredSaleList();
+
+        if (saleIndex.getZeroBased() >= lastShownList.size()) {
+            throw new CommandException(Messages.MESSAGE_INVALID_SALE_DISPLAYED_INDEX);
+        }
+
+        if(personIndex != null) {
+            List<Person> lastShownPeople = model.getSortedPersonList();
+            if (personIndex.getZeroBased() >= lastShownPeople.size()) {
+                throw new CommandException(Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
+            }
+
+            Person newBuyer = lastShownPeople.get(personIndex.getZeroBased());
+            editSaleDescriptor.setBuyerId(newBuyer.getId());
+        }
+
+        Sale saleToEdit = lastShownList.get(saleIndex.getZeroBased());
+        Sale editedSale = createEditedSale(saleToEdit, editSaleDescriptor);
+
+        if (!model.saleTagsExist(editedSale)) {
+            throw new CommandException(Messages.MESSAGE_SALE_TAGS_NOT_FOUND);
+        }
+
+        if (!saleToEdit.isSameSale(editedSale) && model.hasSale(editedSale)) {
+            throw new CommandException(MESSAGE_DUPLICATE_SALE);
+        }
+
+        model.setSale(saleToEdit, editedSale);
+        model.updateFilteredSaleList(PREDICATE_SHOW_ALL_SALES);
+        return new CommandResult(String.format(MESSAGE_EDIT_SALE_SUCCESS, editedSale));
+    }
+
+    /**
+     * Creates and returns a {@code Sale} with the details of {@code saleToEdit}
+     * edited with {@code editPersonDescriptor}.
+     */
+    private static Sale createEditedSale(Sale saleToEdit, EditSaleDescriptor editSaleDescriptor) {
+        assert saleToEdit != null;
+
+        ItemName updatedItemName = editSaleDescriptor.getItemName().orElse(saleToEdit.getItemName());
+        int updatedBuyerId = editSaleDescriptor.getBuyerId().orElse(saleToEdit.getBuyerId());
+        LocalDateTime updatedDatetimeOfPurchase = editSaleDescriptor.getDatetimeOfPurchase()
+                .orElse(saleToEdit.getDatetimeOfPurchase());
+        UnitPrice updatedUnitPrice = editSaleDescriptor.getUnitPrice().orElse(saleToEdit.getUnitPrice());
+        Quantity updatedQuantity = editSaleDescriptor.getQuantity().orElse(saleToEdit.getQuantity());
+        Set<Tag> updatedTags = editSaleDescriptor.getTags().orElse(saleToEdit.getTags());
+
+        return new Sale(updatedItemName, updatedBuyerId, updatedDatetimeOfPurchase, updatedQuantity, updatedUnitPrice,
+                updatedTags);
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        // short circuit if same object
+        if (other == this) {
+            return true;
+        }
+
+        // instanceof handles nulls
+        if (!(other instanceof EditCommand)) {
+            return false;
+        }
+
+        // state check
+        EditCommand e = (EditCommand) other;
+        return saleIndex.equals(e.saleIndex)
+                && editSaleDescriptor.equals(e.editSaleDescriptor);
+    }
+
+    /**
+     * Stores the details to edit the sale with. Each non-empty field value will replace the
+     * corresponding field value of the sale.
+     */
+    public static class EditSaleDescriptor {
+        private int buyerId;
+        private ItemName itemName;
+        private LocalDateTime datetimeOfPurchase;
+        private Quantity quantity;
+        private UnitPrice unitPrice;
+        private Set<Tag> tagList;
+
+
+        public EditSaleDescriptor() {}
+
+        /**
+         * Copy constructor.
+         * A defensive copy of {@code tags} is used internally.
+         */
+        public EditSaleDescriptor(EditSaleDescriptor toCopy) {
+            setBuyerId(toCopy.buyerId);
+            setItemName(toCopy.itemName);
+            setDatetimeOfPurchase(toCopy.datetimeOfPurchase);
+            setUnitPrice(toCopy.unitPrice);
+            setQuantity(toCopy.quantity);
+            setTags(toCopy.tagList);
+        }
+
+        /**
+         * Returns true if at least one field is edited.
+         */
+        public boolean isAnyFieldEdited() {
+            return CollectionUtil.isAnyNonNull(buyerId, itemName, datetimeOfPurchase, unitPrice, quantity, tagList);
+        }
+
+        public void setBuyerId(int id) {
+            this.buyerId = id;
+        }
+
+        public Optional<Integer> getBuyerId() {
+            return Optional.ofNullable(buyerId);
+        }
+
+        public void setItemName(ItemName itemName) {
+            this.itemName = itemName;
+        }
+
+        public Optional<ItemName> getItemName() {
+            return Optional.ofNullable(itemName);
+        }
+
+        public void setDatetimeOfPurchase(LocalDateTime datetimeOfPurchase) {
+            this.datetimeOfPurchase = datetimeOfPurchase;
+        }
+
+        public Optional<LocalDateTime> getDatetimeOfPurchase() {
+            return Optional.ofNullable(datetimeOfPurchase);
+        }
+
+        public void setUnitPrice(UnitPrice unitPrice) {
+            this.unitPrice = unitPrice;
+        }
+
+        public Optional<UnitPrice> getUnitPrice() {
+            return Optional.ofNullable(unitPrice);
+        }
+
+        public void setQuantity(Quantity quantity) {
+            this.quantity = quantity;
+        }
+
+        public Optional<Quantity> getQuantity() {
+            return Optional.ofNullable(quantity);
+        }
+
+        /**
+         * Sets {@code tags} to this object's {@code tags}.
+         * A defensive copy of {@code tags} is used internally.
+         */
+        public void setTags(Set<Tag> tags) {
+            this.tagList = (tags != null) ? new HashSet<>(tags) : null;
+        }
+
+        /**
+         * Returns an unmodifiable tag set, which throws {@code UnsupportedOperationException}
+         * if modification is attempted.
+         * Returns {@code Optional#empty()} if {@code tags} is null.
+         */
+        public Optional<Set<Tag>> getTags() {
+            return (tagList != null) ? Optional.of(Collections.unmodifiableSet(tagList)) : Optional.empty();
+        }
+
+        @Override
+        public boolean equals(Object other) {
+            // short circuit if same object
+            if (other == this) {
+                return true;
+            }
+
+            // instanceof handles nulls
+            if (!(other instanceof EditSaleDescriptor)) {
+                return false;
+            }
+
+            // state check
+            EditSaleDescriptor e = (EditSaleDescriptor) other;
+
+            return getBuyerId().equals(e.getBuyerId())
+                    && getItemName().equals(e.getItemName())
+                    && getDatetimeOfPurchase().equals(e.getDatetimeOfPurchase())
+                    && getUnitPrice().equals(e.getUnitPrice())
+                    && getQuantity().equals(e.getQuantity())
+                    && getTags().equals(e.getTags());
+        }
+    }
+}

--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -33,6 +33,7 @@ import seedu.address.model.tag.Tag;
 public class ParserUtil {
 
     public static final String MESSAGE_INVALID_INDEX = "Index is not a non-zero unsigned integer.";
+    public static final DateTimeFormatter dateTimeFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm");
 
     /**
      * Returns true if none of the prefixes contains empty {@code Optional} values in the given
@@ -161,7 +162,6 @@ public class ParserUtil {
     public static LocalDateTime parseDateTime(String dateTime) throws ParseException {
         requireNonNull(dateTime);
         String trimmedDateTime = dateTime.trim();
-        DateTimeFormatter dateTimeFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm");
 
         try {
             return LocalDateTime.parse(trimmedDateTime, dateTimeFormatter);

--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -33,7 +33,7 @@ import seedu.address.model.tag.Tag;
 public class ParserUtil {
 
     public static final String MESSAGE_INVALID_INDEX = "Index is not a non-zero unsigned integer.";
-    public static final DateTimeFormatter dateTimeFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm");
+    public static final DateTimeFormatter DATE_TIME_FORMATTER = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm");
 
     /**
      * Returns true if none of the prefixes contains empty {@code Optional} values in the given
@@ -164,7 +164,7 @@ public class ParserUtil {
         String trimmedDateTime = dateTime.trim();
 
         try {
-            return LocalDateTime.parse(trimmedDateTime, dateTimeFormatter);
+            return LocalDateTime.parse(trimmedDateTime, DATE_TIME_FORMATTER);
         } catch (DateTimeParseException e) {
             throw new ParseException(MESSAGE_INVALID_DATETIME);
         }

--- a/src/main/java/seedu/address/logic/parser/sale/EditCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/sale/EditCommandParser.java
@@ -2,11 +2,6 @@ package seedu.address.logic.parser.sale;
 
 import static java.util.Objects.requireNonNull;
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_CONTACT_ADDRESS;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_CONTACT_EMAIL;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_CONTACT_NAME;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_CONTACT_PHONE;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_CONTACT_REMARK;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_SALE_CONTACT_INDEX;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_SALE_DATE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_SALE_NAME;
@@ -63,7 +58,8 @@ public class EditCommandParser implements Parser<EditCommand> {
             personIndex = ParserUtil.parseIndex(argMultimap.getValue(PREFIX_SALE_CONTACT_INDEX).get());
         }
         if (argMultimap.getValue(PREFIX_SALE_DATE).isPresent()) {
-            editSaleDescriptor.setDatetimeOfPurchase(ParserUtil.parseDateTime(argMultimap.getValue(PREFIX_SALE_DATE).get()));
+            editSaleDescriptor.setDatetimeOfPurchase(
+                    ParserUtil.parseDateTime(argMultimap.getValue(PREFIX_SALE_DATE).get()));
         }
         if (argMultimap.getValue(PREFIX_SALE_QUANTITY).isPresent()) {
             editSaleDescriptor.setQuantity(
@@ -71,7 +67,8 @@ public class EditCommandParser implements Parser<EditCommand> {
         }
         parseTagsForEdit(argMultimap.getAllValues(PREFIX_TAG)).ifPresent(editSaleDescriptor::setTags);
         if (argMultimap.getValue(PREFIX_SALE_UNIT_PRICE).isPresent()) {
-            editSaleDescriptor.setUnitPrice(ParserUtil.parseUnitPrice(argMultimap.getValue(PREFIX_SALE_UNIT_PRICE).get()));
+            editSaleDescriptor.setUnitPrice(
+                    ParserUtil.parseUnitPrice(argMultimap.getValue(PREFIX_SALE_UNIT_PRICE).get()));
         }
 
         if (!editSaleDescriptor.isAnyFieldEdited()) {

--- a/src/main/java/seedu/address/logic/parser/sale/EditCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/sale/EditCommandParser.java
@@ -1,0 +1,99 @@
+package seedu.address.logic.parser.sale;
+
+import static java.util.Objects.requireNonNull;
+import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_CONTACT_ADDRESS;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_CONTACT_EMAIL;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_CONTACT_NAME;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_CONTACT_PHONE;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_CONTACT_REMARK;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_SALE_CONTACT_INDEX;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_SALE_DATE;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_SALE_NAME;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_SALE_QUANTITY;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_SALE_UNIT_PRICE;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Optional;
+import java.util.Set;
+
+import seedu.address.commons.core.index.Index;
+import seedu.address.logic.commands.sale.EditCommand;
+import seedu.address.logic.commands.sale.EditCommand.EditSaleDescriptor;
+import seedu.address.logic.parser.ArgumentMultimap;
+import seedu.address.logic.parser.ArgumentTokenizer;
+import seedu.address.logic.parser.Parser;
+import seedu.address.logic.parser.ParserUtil;
+import seedu.address.logic.parser.exceptions.ParseException;
+import seedu.address.model.tag.Tag;
+
+/**
+ * Parses input arguments and creates a new EditCommand object for Sale
+ */
+public class EditCommandParser implements Parser<EditCommand> {
+
+    /**
+     * Parses the given {@code String} of arguments in the context of the EditCommand
+     * and returns an EditCommand object for execution.
+     * @throws ParseException if the user input does not conform the expected format
+     */
+    public EditCommand parse(String args) throws ParseException {
+        requireNonNull(args);
+        ArgumentMultimap argMultimap =
+                ArgumentTokenizer.tokenize(args, PREFIX_SALE_CONTACT_INDEX, PREFIX_SALE_NAME,
+                        PREFIX_SALE_DATE, PREFIX_SALE_QUANTITY, PREFIX_TAG, PREFIX_SALE_UNIT_PRICE);
+
+        Index saleIndex;
+        Index personIndex = null;
+
+        try {
+            saleIndex = ParserUtil.parseIndex(argMultimap.getPreamble());
+        } catch (ParseException pe) {
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, EditCommand.MESSAGE_USAGE), pe);
+        }
+
+        EditSaleDescriptor editSaleDescriptor = new EditSaleDescriptor();
+        if (argMultimap.getValue(PREFIX_SALE_NAME).isPresent()) {
+            editSaleDescriptor.setItemName(ParserUtil.parseItemName(argMultimap.getValue(PREFIX_SALE_NAME).get()));
+        }
+
+        if (argMultimap.getValue(PREFIX_SALE_CONTACT_INDEX).isPresent()) {
+            personIndex = ParserUtil.parseIndex(argMultimap.getValue(PREFIX_SALE_CONTACT_INDEX).get());
+        }
+        if (argMultimap.getValue(PREFIX_SALE_DATE).isPresent()) {
+            editSaleDescriptor.setDatetimeOfPurchase(ParserUtil.parseDateTime(argMultimap.getValue(PREFIX_SALE_DATE).get()));
+        }
+        if (argMultimap.getValue(PREFIX_SALE_QUANTITY).isPresent()) {
+            editSaleDescriptor.setQuantity(
+                    ParserUtil.parseQuantity(argMultimap.getValue(PREFIX_SALE_QUANTITY).get()));
+        }
+        parseTagsForEdit(argMultimap.getAllValues(PREFIX_TAG)).ifPresent(editSaleDescriptor::setTags);
+        if (argMultimap.getValue(PREFIX_SALE_UNIT_PRICE).isPresent()) {
+            editSaleDescriptor.setUnitPrice(ParserUtil.parseUnitPrice(argMultimap.getValue(PREFIX_SALE_UNIT_PRICE).get()));
+        }
+
+        if (!editSaleDescriptor.isAnyFieldEdited()) {
+            throw new ParseException(EditCommand.MESSAGE_NOT_EDITED);
+        }
+
+        return new EditCommand(saleIndex, editSaleDescriptor, personIndex);
+    }
+
+    /**
+     * Parses {@code Collection<String> tags} into a {@code Set<Tag>} if {@code tags} is non-empty.
+     * If {@code tags} contain only one element which is an empty string, it will be parsed into a
+     * {@code Set<Tag>} containing zero tags.
+     */
+    private Optional<Set<Tag>> parseTagsForEdit(Collection<String> tags) throws ParseException {
+        assert tags != null;
+
+        if (tags.isEmpty()) {
+            return Optional.empty();
+        }
+        Collection<String> tagSet = tags.size() == 1 && tags.contains("") ? Collections.emptySet() : tags;
+        return Optional.of(ParserUtil.parseTags(tagSet));
+    }
+
+}

--- a/src/main/java/seedu/address/logic/parser/sale/SaleCommandsParser.java
+++ b/src/main/java/seedu/address/logic/parser/sale/SaleCommandsParser.java
@@ -7,6 +7,7 @@ import seedu.address.logic.commands.Command;
 import seedu.address.logic.commands.UnknownCommand;
 import seedu.address.logic.commands.sale.AddCommand;
 import seedu.address.logic.commands.sale.DeleteCommand;
+import seedu.address.logic.commands.sale.EditCommand;
 import seedu.address.logic.commands.sale.ListCommand;
 import seedu.address.logic.parser.GroupCommandsParser;
 import seedu.address.logic.parser.exceptions.ParseException;
@@ -41,6 +42,9 @@ public class SaleCommandsParser implements GroupCommandsParser {
 
         case ListCommand.COMMAND_WORD:
             return new ListCommandParser().parse(arguments);
+
+        case EditCommand.COMMAND_WORD:
+            return new EditCommandParser().parse(arguments);
 
         default:
             return new UnknownCommand(commandWord);

--- a/src/main/java/seedu/address/model/AddressBook.java
+++ b/src/main/java/seedu/address/model/AddressBook.java
@@ -210,7 +210,7 @@ public class AddressBook implements ReadOnlyAddressBook {
 
         sales.setSale(target, editedSale);
         for (Tag t : editedSale.getTags()) {
-            contactTags.add(t);
+            saleTags.add(t);
         }
     }
 

--- a/src/main/java/seedu/address/model/AddressBook.java
+++ b/src/main/java/seedu/address/model/AddressBook.java
@@ -201,6 +201,20 @@ public class AddressBook implements ReadOnlyAddressBook {
     }
 
     /**
+     * Replaces the given sale {@code target} in the list with {@code editedSale}.
+     * {@code target} must exist in the address book.
+     * The sale identity of {@code editedSale} must not be the same as another existing sale in the address book.
+     */
+    public void setSale(Sale target, Sale editedSale) {
+        requireNonNull(editedSale);
+
+        sales.setSale(target, editedSale);
+        for (Tag t : editedSale.getTags()) {
+            contactTags.add(t);
+        }
+    }
+
+    /**
      * Removes {@code key} from this {@code AddressBook}.
      * {@code key} must exist in the address book.
      *

--- a/src/main/java/seedu/address/model/Model.java
+++ b/src/main/java/seedu/address/model/Model.java
@@ -29,6 +29,11 @@ public interface Model {
             person1.getName().fullName.compareToIgnoreCase(person2.getName().fullName));
 
     /**
+     * {@code Predicate} that always evaluate to true.
+     */
+    Predicate<Sale> PREDICATE_SHOW_ALL_SALES = unused -> true;
+
+    /**
      * Replaces user prefs data with the data in {@code userPrefs}.
      */
     void setUserPrefs(ReadOnlyUserPrefs userPrefs);
@@ -280,6 +285,13 @@ public interface Model {
      * {@code sale} must not already exist in StonksBook.
      */
     void addSale(Sale sale);
+
+    /**
+     * Replaces the given sale {@code target} with {@code editedSale}.
+     * {@code target} must exist in the address book.
+     * The sale identity of {@code editedSale} must not be the same as another existing sale in the address book.
+     */
+    void setSale(Sale target, Sale editedSale);
 
     /**
      * Removes the given sale.

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -405,6 +405,7 @@ public class ModelManager implements Model {
                 && this.userPrefs.equals(other.userPrefs)
                 && this.sortedPersons.equals(other.sortedPersons)
                 && this.sortedMeetings.equals(other.sortedMeetings)
-                && this.sortedReminders.equals(other.sortedReminders);
+                && this.sortedReminders.equals(other.sortedReminders)
+                && this.sortedSales.equals(other.sortedSales);
     }
 }

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -54,7 +54,6 @@ public class ModelManager implements Model {
         this.userPrefs = new UserPrefs(userPrefs);
         this.filteredPersons = new FilteredList<>(this.addressBook.getPersonList());
         this.filteredSales = new FilteredList<>(this.addressBook.getSaleList());
-        this.filteredSales.setPredicate(x -> false);
         this.sortedPersons = new SortedList<>(this.filteredPersons);
         this.updateSortedPersonList(DEFAULT_PERSON_COMPARATOR);
         this.sortedMeetings = new SortedList<>(this.addressBook.getMeetingList(), Comparator.naturalOrder());
@@ -225,6 +224,12 @@ public class ModelManager implements Model {
     @Override
     public void addSale(Sale sale) {
         addressBook.addSale(sale);
+    }
+
+    @Override
+    public void setSale(Sale target, Sale editedSale) {
+        requireAllNonNull(target, editedSale);
+        this.addressBook.setSale(target, editedSale);
     }
 
     @Override

--- a/src/main/java/seedu/address/model/sale/Sale.java
+++ b/src/main/java/seedu/address/model/sale/Sale.java
@@ -89,6 +89,18 @@ public class Sale implements Comparable<Sale> {
             return true;
         }
 
+
+//        System.out.println(otherSale.getItemName());
+//        System.out.println(getItemName());
+//        System.out.println(otherSale != null);
+//        System.out.println(otherSale.getItemName().equals(getItemName()));
+//        System.out.println(otherSale.getBuyerId() == (getBuyerId()));
+//        System.out.println(otherSale.getBuyerId());
+//        System.out.println(getBuyerId());
+//        System.out.println(otherSale.getDatetimeOfPurchase().equals(getDatetimeOfPurchase()));
+//        System.out.println(otherSale.getUnitPrice().equals(getUnitPrice()));
+//        System.out.println(otherSale.getQuantity().equals(getQuantity()));
+//        System.out.println("-----");
         return otherSale != null
                 && otherSale.getItemName().equals(getItemName())
                 && otherSale.getBuyerId() == (getBuyerId())

--- a/src/main/java/seedu/address/model/sale/Sale.java
+++ b/src/main/java/seedu/address/model/sale/Sale.java
@@ -89,18 +89,6 @@ public class Sale implements Comparable<Sale> {
             return true;
         }
 
-
-//        System.out.println(otherSale.getItemName());
-//        System.out.println(getItemName());
-//        System.out.println(otherSale != null);
-//        System.out.println(otherSale.getItemName().equals(getItemName()));
-//        System.out.println(otherSale.getBuyerId() == (getBuyerId()));
-//        System.out.println(otherSale.getBuyerId());
-//        System.out.println(getBuyerId());
-//        System.out.println(otherSale.getDatetimeOfPurchase().equals(getDatetimeOfPurchase()));
-//        System.out.println(otherSale.getUnitPrice().equals(getUnitPrice()));
-//        System.out.println(otherSale.getQuantity().equals(getQuantity()));
-//        System.out.println("-----");
         return otherSale != null
                 && otherSale.getItemName().equals(getItemName())
                 && otherSale.getBuyerId() == (getBuyerId())

--- a/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
+++ b/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
@@ -25,7 +25,8 @@ import java.util.Arrays;
 import java.util.List;
 
 import seedu.address.commons.core.index.Index;
-import seedu.address.logic.commands.contact.EditCommand;
+import seedu.address.logic.commands.contact.EditCommand.EditPersonDescriptor;
+import seedu.address.logic.commands.sale.EditCommand.EditSaleDescriptor;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.AddressBook;
 import seedu.address.model.Model;
@@ -36,8 +37,10 @@ import seedu.address.model.person.NameContainsKeywordsPredicate;
 import seedu.address.model.person.Person;
 import seedu.address.model.person.Phone;
 import seedu.address.model.person.Remark;
+import seedu.address.model.sale.Sale;
 import seedu.address.model.tag.Tag;
 import seedu.address.testutil.person.EditPersonDescriptorBuilder;
+import seedu.address.testutil.sale.EditSaleDescriptorBuilder;
 
 /**
  * Contains helper methods for testing commands.
@@ -104,8 +107,8 @@ public class CommandTestUtil {
     public static final String PREAMBLE_WHITESPACE = "\t  \r  \n";
     public static final String PREAMBLE_NON_EMPTY = "NonEmptyPreamble";
 
-    public static final EditCommand.EditPersonDescriptor DESC_AMY;
-    public static final EditCommand.EditPersonDescriptor DESC_BOB;
+    public static final EditPersonDescriptor DESC_AMY;
+    public static final EditPersonDescriptor DESC_BOB;
 
     /* Sale commands */
     public static final String VALID_ITEM_NAME_APPLE = "Apple";
@@ -116,7 +119,7 @@ public class CommandTestUtil {
     public static final String VALID_QUANTITY_BALL = "1";
     public static final String VALID_UNIT_PRICE_APPLE = "3.50";
     public static final String VALID_UNIT_PRICE_BALL = "0.8";
-    public static final String VALID_EMPTY_SALE_TAG = "";
+    public static final String VALID_SALE_TAG_EMPTY = "";
     public static final String VALID_SALE_TAG_FRUITS = "fruits";
 
     public static final String INVALID_ITEM_NAME = " " + PREFIX_SALE_NAME + "@pple";
@@ -132,6 +135,9 @@ public class CommandTestUtil {
 
     public static final String VALID_SALE_TAG = " " + PREFIX_TAG + VALID_SALE_TAG_FRUITS;
 
+    public static final EditSaleDescriptor DESC_APPLE;
+    public static final EditSaleDescriptor DESC_BALL;
+
     static {
         DESC_AMY = new EditPersonDescriptorBuilder().withName(VALID_NAME_AMY)
             .withPhone(VALID_PHONE_AMY).withEmail(VALID_EMAIL_AMY).withAddress(VALID_ADDRESS_AMY)
@@ -139,6 +145,15 @@ public class CommandTestUtil {
         DESC_BOB = new EditPersonDescriptorBuilder().withName(VALID_NAME_BOB)
             .withPhone(VALID_PHONE_BOB).withEmail(VALID_EMAIL_BOB).withAddress(VALID_ADDRESS_BOB)
             .withTags(VALID_TAG_HUSBAND, VALID_TAG_FRIEND).build();
+    }
+
+    static {
+        DESC_APPLE = new EditSaleDescriptorBuilder().withItemName(VALID_ITEM_NAME_APPLE).withBuyer(1)
+                .withDatetimeOfPurchase(VALID_DATE_APPLE).withUnitPrice(VALID_UNIT_PRICE_APPLE)
+                .withQuantity(VALID_QUANTITY_APPLE).withTags(VALID_SALE_TAG_FRUITS).build();
+        DESC_BALL = new EditSaleDescriptorBuilder().withItemName(VALID_ITEM_NAME_BALL).withBuyer(2)
+                .withDatetimeOfPurchase(VALID_DATE_BALL).withUnitPrice(VALID_UNIT_PRICE_BALL)
+                .withQuantity(VALID_QUANTITY_BALL).withTags().build();
     }
 
     /**
@@ -196,6 +211,22 @@ public class CommandTestUtil {
         model.updateFilteredPersonList(new NameContainsKeywordsPredicate(Arrays.asList(splitName[0])));
 
         assertEquals(1, model.getFilteredPersonList().size());
+    }
+
+    /**
+     * Updates {@code model}'s filtered list to show only the sale at the given {@code targetIndex} in the
+     * {@code model}'s address book.
+     */
+    public static void showSaleAtIndex(Model model, Index targetIndex) {
+        assertTrue(targetIndex.getZeroBased() < model.getFilteredSaleList().size());
+
+        Sale sale = model.getFilteredSaleList().get(targetIndex.getZeroBased());
+        System.out.println(sale);
+        System.out.println(sale.getBuyerId());
+        System.out.println("_+_+_+_+_+_");
+        model.updateFilteredSaleList(x -> x.equals(sale));
+
+        assertEquals(1, model.getFilteredSaleList().size());
     }
 
     /**

--- a/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
+++ b/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
@@ -26,8 +26,8 @@ import java.util.List;
 
 import seedu.address.commons.core.index.Index;
 import seedu.address.logic.commands.contact.EditCommand.EditPersonDescriptor;
-import seedu.address.logic.commands.sale.EditCommand.EditSaleDescriptor;
 import seedu.address.logic.commands.exceptions.CommandException;
+import seedu.address.logic.commands.sale.EditCommand.EditSaleDescriptor;
 import seedu.address.model.AddressBook;
 import seedu.address.model.Model;
 import seedu.address.model.person.Address;

--- a/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
+++ b/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
@@ -221,9 +221,6 @@ public class CommandTestUtil {
         assertTrue(targetIndex.getZeroBased() < model.getFilteredSaleList().size());
 
         Sale sale = model.getFilteredSaleList().get(targetIndex.getZeroBased());
-        System.out.println(sale);
-        System.out.println(sale.getBuyerId());
-        System.out.println("_+_+_+_+_+_");
         model.updateFilteredSaleList(x -> x.equals(sale));
 
         assertEquals(1, model.getFilteredSaleList().size());

--- a/src/test/java/seedu/address/logic/commands/sale/DeleteCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/sale/DeleteCommandTest.java
@@ -33,6 +33,7 @@ public class DeleteCommandTest {
 
     @Test
     public void execute_noSalesListed_throwsCommandException() {
+        model.updateFilteredSaleList(x -> false);
         Sale saleToDelete = model.getSortedSaleList().get(0);
         DeleteCommand deleteCommand = new DeleteCommand(INDEX_SECOND_ITEM);
 

--- a/src/test/java/seedu/address/logic/commands/sale/EditCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/sale/EditCommandTest.java
@@ -1,0 +1,185 @@
+package seedu.address.logic.commands.sale;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.address.logic.commands.CommandTestUtil.DESC_APPLE;
+import static seedu.address.logic.commands.CommandTestUtil.DESC_BALL;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_ITEM_NAME_APPLE;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_ITEM_NAME_BALL;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_QUANTITY_APPLE;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_SALE_TAG_FRUITS;
+import static seedu.address.logic.commands.CommandTestUtil.assertCommandFailure;
+import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
+import static seedu.address.logic.commands.CommandTestUtil.showSaleAtIndex;
+import static seedu.address.testutil.TypicalAddressBook.getTypicalAddressBookInReverse;
+import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_ITEM;
+import static seedu.address.testutil.TypicalIndexes.INDEX_SECOND_ITEM;
+import static seedu.address.testutil.TypicalIndexes.INDEX_THIRD_ITEM;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.commons.core.Messages;
+import seedu.address.commons.core.index.Index;
+import seedu.address.logic.commands.PurgeCommand;
+import seedu.address.logic.commands.sale.EditCommand.EditSaleDescriptor;
+import seedu.address.model.AddressBook;
+import seedu.address.model.Model;
+import seedu.address.model.ModelManager;
+import seedu.address.model.UserPrefs;
+import seedu.address.model.sale.Sale;
+import seedu.address.model.tag.Tag;
+import seedu.address.testutil.sale.EditSaleDescriptorBuilder;
+import seedu.address.testutil.sale.SaleBuilder;
+
+/**
+ * Contains integration tests (interaction with the Model, UndoCommand and RedoCommand) and unit tests for EditCommand.
+ */
+public class EditCommandTest {
+
+    private Model model = new ModelManager(getTypicalAddressBookInReverse(), new UserPrefs());
+
+    @Test
+    public void execute_allFieldsSpecifiedUnfilteredList_success() {
+        Sale editedSale = new SaleBuilder().withItemName("Tissue Box").withBuyerId(1).build();
+        EditSaleDescriptor descriptor = new EditSaleDescriptorBuilder(editedSale).withItemName("Tissue Box").build();
+        EditCommand editCommand = new EditCommand(INDEX_FIRST_ITEM, descriptor, INDEX_FIRST_ITEM);
+
+        String expectedMessage = String.format(EditCommand.MESSAGE_EDIT_SALE_SUCCESS, editedSale);
+
+        Model expectedModel = new ModelManager(new AddressBook(model.getAddressBook()), new UserPrefs());
+        expectedModel.setSale(model.getSortedSaleList().get(2), editedSale);
+
+        assertCommandSuccess(editCommand, model, expectedMessage, expectedModel);
+    }
+
+    @Test
+    public void execute_someFieldsSpecifiedUnfilteredList_success() {
+        model.addContactTag(new Tag(VALID_SALE_TAG_FRUITS));
+        Index indexLastSale = Index.fromOneBased(model.getSortedSaleList().size());
+        Sale lastSale = model.getSortedSaleList().get(indexLastSale.getZeroBased());
+
+        SaleBuilder saleInList = new SaleBuilder(lastSale);
+        Sale editedSale = saleInList.withItemName(VALID_ITEM_NAME_BALL).withQuantity(VALID_QUANTITY_APPLE)
+            .withTags(VALID_SALE_TAG_FRUITS).withBuyerId(1).build();
+
+        EditSaleDescriptor descriptor = new EditSaleDescriptorBuilder().withItemName(VALID_ITEM_NAME_BALL)
+            .withQuantity(VALID_QUANTITY_APPLE).withTags(VALID_SALE_TAG_FRUITS).build();
+        EditCommand editCommand = new EditCommand(INDEX_FIRST_ITEM, descriptor, INDEX_FIRST_ITEM);
+
+        String expectedMessage = String.format(EditCommand.MESSAGE_EDIT_SALE_SUCCESS, editedSale);
+
+        Model expectedModel = new ModelManager(new AddressBook(model.getAddressBook()), new UserPrefs());
+        expectedModel.setSale(lastSale, editedSale);
+
+        assertCommandSuccess(editCommand, model, expectedMessage, expectedModel);
+    }
+
+    @Test
+    public void execute_noFieldSpecifiedUnfilteredList_success() {
+        EditCommand editCommand = new EditCommand(INDEX_FIRST_ITEM, new EditSaleDescriptor(), null);
+        Sale editedSale = model.getFilteredSaleList().get(INDEX_FIRST_ITEM.getZeroBased());
+
+        String expectedMessage = String.format(EditCommand.MESSAGE_EDIT_SALE_SUCCESS, editedSale);
+
+        Model expectedModel = new ModelManager(new AddressBook(model.getAddressBook()), new UserPrefs());
+
+        assertCommandSuccess(editCommand, model, expectedMessage, expectedModel);
+    }
+
+    @Test
+    public void execute_filteredList_success() {
+        showSaleAtIndex(model, INDEX_SECOND_ITEM);
+
+        Sale saleInFilteredList = model.getSortedSaleList().get(INDEX_FIRST_ITEM.getZeroBased());
+        Sale editedSale = new SaleBuilder(saleInFilteredList).withItemName(VALID_ITEM_NAME_APPLE)
+                .build();
+        EditCommand editCommand = new EditCommand(INDEX_FIRST_ITEM,
+            new EditSaleDescriptorBuilder().withItemName(VALID_ITEM_NAME_APPLE).build(), null);
+
+        String expectedMessage = String.format(EditCommand.MESSAGE_EDIT_SALE_SUCCESS, editedSale);
+
+        Model expectedModel = new ModelManager(new AddressBook(model.getAddressBook()), new UserPrefs());
+        expectedModel.setSale(model.getSortedSaleList().get(0), editedSale);
+
+        assertCommandSuccess(editCommand, model, expectedMessage, expectedModel);
+    }
+
+    @Test
+    public void execute_duplicatePersonUnfilteredList_failure() {
+        Sale firstSale = model.getSortedSaleList().get(INDEX_FIRST_ITEM.getZeroBased());
+        EditSaleDescriptor descriptor = new EditSaleDescriptorBuilder(firstSale).build();
+        EditCommand editCommand = new EditCommand(INDEX_THIRD_ITEM, descriptor, INDEX_FIRST_ITEM);
+
+        assertCommandFailure(editCommand, model, EditCommand.MESSAGE_DUPLICATE_SALE);
+    }
+
+    @Test
+    public void execute_duplicatePersonFilteredList_failure() {
+        showSaleAtIndex(model, INDEX_FIRST_ITEM);
+        // edit sale in filtered list into a duplicate in address book
+        Sale saleInList = model.getAddressBook().getSaleList().get(INDEX_SECOND_ITEM.getZeroBased());
+
+        EditCommand editCommand = new EditCommand(INDEX_FIRST_ITEM,
+            new EditSaleDescriptorBuilder(saleInList).build(), INDEX_FIRST_ITEM);
+
+        assertCommandFailure(editCommand, model, EditCommand.MESSAGE_DUPLICATE_SALE);
+    }
+
+    @Test
+    public void execute_invalidPersonIndexUnfilteredList_failure() {
+        Index outOfBoundIndex = Index.fromOneBased(model.getSortedPersonList().size() + 1);
+        EditSaleDescriptor descriptor = new EditSaleDescriptorBuilder().withItemName(VALID_ITEM_NAME_BALL).build();
+        EditCommand editCommand = new EditCommand(outOfBoundIndex, descriptor, null);
+
+        assertCommandFailure(editCommand, model, Messages.MESSAGE_INVALID_SALE_DISPLAYED_INDEX);
+    }
+
+    /**
+     * Edit filtered list where index is larger than size of filtered list,
+     * but smaller than size of address book
+     */
+    @Test
+    public void execute_invalidSaleIndexFilteredList_failure() {
+        showSaleAtIndex(model, INDEX_FIRST_ITEM);
+        Index outOfBoundIndex = INDEX_SECOND_ITEM;
+        // ensures that outOfBoundIndex is still in bounds of address book list
+        assertTrue(outOfBoundIndex.getZeroBased() < model.getAddressBook().getSaleList().size());
+
+        EditCommand editCommand = new EditCommand(outOfBoundIndex,
+            new EditSaleDescriptorBuilder().withItemName(VALID_ITEM_NAME_BALL).build(), null);
+
+        assertCommandFailure(editCommand, model, Messages.MESSAGE_INVALID_SALE_DISPLAYED_INDEX);
+    }
+
+    @Test
+    public void equals() {
+        final EditCommand standardCommand = new EditCommand(INDEX_FIRST_ITEM, DESC_APPLE, INDEX_SECOND_ITEM);
+
+        // same values -> returns true
+        EditSaleDescriptor copyDescriptor = new EditSaleDescriptor(DESC_APPLE);
+        EditCommand commandWithSameValues = new EditCommand(INDEX_FIRST_ITEM, copyDescriptor, INDEX_SECOND_ITEM);
+        assertTrue(standardCommand.equals(commandWithSameValues));
+
+        // same object -> returns true
+        assertTrue(standardCommand.equals(standardCommand));
+
+        // null -> returns false
+        assertFalse(standardCommand.equals(null));
+
+        // different types -> returns false
+        assertFalse(standardCommand.equals(new PurgeCommand()));
+
+        // different index -> returns false
+        assertFalse(standardCommand.equals(new EditCommand(INDEX_SECOND_ITEM, DESC_APPLE, INDEX_SECOND_ITEM)));
+
+        // different descriptor -> returns false
+        assertFalse(standardCommand.equals(new EditCommand(INDEX_FIRST_ITEM, DESC_BALL, INDEX_SECOND_ITEM)));
+
+        // different person index -> returns false
+        assertFalse(standardCommand.equals(new EditCommand(INDEX_FIRST_ITEM, DESC_APPLE, INDEX_FIRST_ITEM)));
+
+        // null person index -> returns false
+        assertFalse(standardCommand.equals(new EditCommand(INDEX_FIRST_ITEM, DESC_APPLE, null)));
+    }
+
+}

--- a/src/test/java/seedu/address/logic/commands/sale/EditSaleDescriptorTest.java
+++ b/src/test/java/seedu/address/logic/commands/sale/EditSaleDescriptorTest.java
@@ -1,0 +1,63 @@
+package seedu.address.logic.commands.sale;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.address.logic.commands.CommandTestUtil.DESC_APPLE;
+import static seedu.address.logic.commands.CommandTestUtil.DESC_BALL;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_DATE_BALL;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_ITEM_NAME_BALL;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_QUANTITY_BALL;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_UNIT_PRICE_BALL;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.logic.commands.sale.EditCommand.EditSaleDescriptor;
+import seedu.address.testutil.sale.EditSaleDescriptorBuilder;
+
+public class EditSaleDescriptorTest {
+
+    @Test
+    public void equals() {
+        // same values -> returns true
+        EditSaleDescriptor descriptorWithSameValues = new EditSaleDescriptor(DESC_APPLE);
+        assertTrue(DESC_APPLE.equals(descriptorWithSameValues));
+
+        // same object -> returns true
+        assertTrue(DESC_APPLE.equals(DESC_APPLE));
+
+        // null -> returns false
+        assertFalse(DESC_APPLE.equals(null));
+
+        // different types -> returns false
+        assertFalse(DESC_APPLE.equals(5));
+
+        // different values -> returns false
+        assertFalse(DESC_APPLE.equals(DESC_BALL));
+
+        // different item name -> returns false
+        EditSaleDescriptor editedApple = new EditSaleDescriptorBuilder(DESC_APPLE)
+                .withItemName(VALID_ITEM_NAME_BALL).build();
+        assertFalse(DESC_APPLE.equals(editedApple));
+
+        // different buyer id -> returns false
+        editedApple = new EditSaleDescriptorBuilder(DESC_APPLE).withBuyer(10).build();
+        assertFalse(DESC_APPLE.equals(editedApple));
+
+        // different datetime -> returns false
+        editedApple = new EditSaleDescriptorBuilder(DESC_APPLE)
+                .withDatetimeOfPurchase(VALID_DATE_BALL).build();
+        assertFalse(DESC_APPLE.equals(editedApple));
+
+        // different unit price -> returns false
+        editedApple = new EditSaleDescriptorBuilder(DESC_APPLE).withUnitPrice(VALID_UNIT_PRICE_BALL).build();
+        assertFalse(DESC_APPLE.equals(editedApple));
+
+        // different quantity -> returns false
+        editedApple = new EditSaleDescriptorBuilder(DESC_APPLE).withQuantity(VALID_QUANTITY_BALL).build();
+        assertFalse(DESC_APPLE.equals(editedApple));
+
+        // different tags -> returns false
+        editedApple = new EditSaleDescriptorBuilder(DESC_APPLE).withTags().build();
+        assertFalse(DESC_APPLE.equals(editedApple));
+    }
+}

--- a/src/test/java/seedu/address/model/ModelStub.java
+++ b/src/test/java/seedu/address/model/ModelStub.java
@@ -247,6 +247,11 @@ public class ModelStub implements Model {
     }
 
     @Override
+    public void setSale(Sale target, Sale editedSale) {
+        throw new AssertionError("This method should not be called.");
+    }
+
+    @Override
     public void removeSale(Sale sale) {
         throw new AssertionError("This method should not be called.");
     }

--- a/src/test/java/seedu/address/testutil/sale/EditSaleDescriptorBuilder.java
+++ b/src/test/java/seedu/address/testutil/sale/EditSaleDescriptorBuilder.java
@@ -1,0 +1,98 @@
+package seedu.address.testutil.sale;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import seedu.address.logic.commands.sale.EditCommand.EditSaleDescriptor;
+import seedu.address.logic.parser.ParserUtil;
+import seedu.address.model.sale.ItemName;
+import seedu.address.model.sale.Quantity;
+import seedu.address.model.sale.Sale;
+import seedu.address.model.sale.UnitPrice;
+import seedu.address.model.tag.Tag;
+
+/**
+ * A utility class to help with building EditSaleDescriptor objects.
+ */
+public class EditSaleDescriptorBuilder {
+
+    private EditSaleDescriptor descriptor;
+
+    public EditSaleDescriptorBuilder() {
+        descriptor = new EditSaleDescriptor();
+    }
+
+    public EditSaleDescriptorBuilder(EditSaleDescriptor descriptor) {
+        this.descriptor = new EditSaleDescriptor(descriptor);
+    }
+
+    /**
+     * Returns an {@code EditSaleDescriptor} with fields containing {@code sale}'s details
+     */
+    public EditSaleDescriptorBuilder(Sale sale) {
+        descriptor = new EditSaleDescriptor();
+        descriptor.setItemName(sale.getItemName());
+        descriptor.setBuyerId(sale.getBuyerId());
+        descriptor.setDatetimeOfPurchase(sale.getDatetimeOfPurchase());
+        descriptor.setUnitPrice(sale.getUnitPrice());
+        descriptor.setQuantity(sale.getQuantity());
+        descriptor.setTags(sale.getTags());
+    }
+
+    /**
+     * Sets the {@code itemName} of the {@code EditSaleDescriptor} that we are building.
+     */
+    public EditSaleDescriptorBuilder withItemName(String itemName) {
+        descriptor.setItemName(new ItemName(itemName));
+        return this;
+    }
+
+    /**
+     * Sets the {@code buyerId} of the {@code EditSaleDescriptor} that we are building.
+     */
+    public EditSaleDescriptorBuilder withBuyer(int buyerId) {
+        descriptor.setBuyerId(buyerId);
+        return this;
+    }
+
+    /**
+     * Sets the {@code localDateTime} of the {@code EditSaleDescriptor} that we are building.
+     */
+    public EditSaleDescriptorBuilder withDatetimeOfPurchase(String localDateTime) {
+        descriptor.setDatetimeOfPurchase(LocalDateTime.parse(localDateTime, ParserUtil.dateTimeFormatter));
+        return this;
+    }
+
+    /**
+     * Sets the {@code unitPrice} of the {@code EditSaleDescriptor} that we are building.
+     */
+    public EditSaleDescriptorBuilder withUnitPrice(String unitPrice) {
+        descriptor.setUnitPrice(new UnitPrice(new BigDecimal(unitPrice)));
+        return this;
+    }
+
+    /**
+     * Sets the {@code Address} of the {@code EditSaleDescriptor} that we are building.
+     */
+    public EditSaleDescriptorBuilder withQuantity(String quantity) {
+        descriptor.setQuantity(new Quantity(quantity));
+        return this;
+    }
+
+    /**
+     * Parses the {@code tags} into a {@code Set<Tag>} and set it to the {@code EditSaleDescriptor}
+     * that we are building.
+     */
+    public EditSaleDescriptorBuilder withTags(String... tags) {
+        Set<Tag> tagSet = Stream.of(tags).map(Tag::new).collect(Collectors.toSet());
+        descriptor.setTags(tagSet);
+        return this;
+    }
+
+    public EditSaleDescriptor build() {
+        return descriptor;
+    }
+}

--- a/src/test/java/seedu/address/testutil/sale/EditSaleDescriptorBuilder.java
+++ b/src/test/java/seedu/address/testutil/sale/EditSaleDescriptorBuilder.java
@@ -62,7 +62,7 @@ public class EditSaleDescriptorBuilder {
      * Sets the {@code localDateTime} of the {@code EditSaleDescriptor} that we are building.
      */
     public EditSaleDescriptorBuilder withDatetimeOfPurchase(String localDateTime) {
-        descriptor.setDatetimeOfPurchase(LocalDateTime.parse(localDateTime, ParserUtil.dateTimeFormatter));
+        descriptor.setDatetimeOfPurchase(LocalDateTime.parse(localDateTime, ParserUtil.DATE_TIME_FORMATTER));
         return this;
     }
 


### PR DESCRIPTION
Closes #107 

**New features/changes**
- Implement the `sale edit` command, which has the syntax `sale edit SALE_INDEX [c/CONTACT_INDEX] [n/ITEM_NAME] [d/DATETIME_OF_PURCHASE] [p/UNIT_PRICE] [q/QUANTITY] [t/TAG]…`
- Tests have been added for the new classes added.

**Implementations**
- Similar to Edit implementations of other classes like `Person`. 
- Consists of `EditCommand`, `EditCommandParser` and `EditSaleDescriptor`


**Demo**

<img width="1322" alt="Screenshot 2020-10-21 at 6 18 24 PM" src="https://user-images.githubusercontent.com/54730257/96707020-eb2ed000-13c9-11eb-8c01-9f50c9ee0382.png">
<img width="1322" alt="Screenshot 2020-10-21 at 6 18 36 PM" src="https://user-images.githubusercontent.com/54730257/96707036-eff38400-13c9-11eb-9ae2-4e66397d0a63.png">