### PR TITLE
Implement user input history

### DIFF
--- a/src/main/java/seedu/address/logic/commands/archive/AddCommand.java
+++ b/src/main/java/seedu/address/logic/commands/archive/AddCommand.java
@@ -43,6 +43,8 @@ public class AddCommand extends Command {
             throw new CommandException(Messages.MESSAGE_ARCHIVE_INVALIID_LIST);
         }
 
+        assert !personToArchive.isArchived();
+
         Person archivedPerson = new Person(
                 personToArchive.getId(),
                 personToArchive.getName(),
@@ -51,7 +53,7 @@ public class AddCommand extends Command {
                 personToArchive.getAddress(),
                 personToArchive.getTags(),
                 personToArchive.getRemark(),
-                true,
+                !personToArchive.isArchived(),
                 personToArchive.getTotalSalesAmount()
         );
         model.setPerson(personToArchive, archivedPerson);

--- a/src/main/java/seedu/address/logic/commands/archive/RemoveCommand.java
+++ b/src/main/java/seedu/address/logic/commands/archive/RemoveCommand.java
@@ -45,6 +45,8 @@ public class RemoveCommand extends Command {
             throw new CommandException(Messages.MESSAGE_UNARCHIVE_INVALIID_LIST);
         }
 
+        assert personToUnarchive.isArchived();
+
         Person unarchivedPerson = new Person(
                 personToUnarchive.getId(),
                 personToUnarchive.getName(),

--- a/src/main/java/seedu/address/ui/CommandBox.java
+++ b/src/main/java/seedu/address/ui/CommandBox.java
@@ -53,7 +53,10 @@ public class CommandBox extends UiPart<Region> {
      */
     @FXML
     private void handleCommandEntered() {
-        userInputHistory.addToHistory(commandTextField.getText());
+        if (!commandTextField.getText().equals("")) {
+            userInputHistory.addToHistory(commandTextField.getText());
+        }
+
         try {
             commandExecutor.execute(commandTextField.getText());
             commandTextField.setText("");

--- a/src/main/java/seedu/address/ui/CommandBox.java
+++ b/src/main/java/seedu/address/ui/CommandBox.java
@@ -2,6 +2,8 @@ package seedu.address.ui;
 
 import javafx.fxml.FXML;
 import javafx.scene.control.TextField;
+import javafx.scene.input.KeyCode;
+import javafx.scene.input.KeyEvent;
 import javafx.scene.layout.Region;
 import seedu.address.logic.commands.CommandResult;
 import seedu.address.logic.commands.exceptions.CommandException;
@@ -15,6 +17,7 @@ public class CommandBox extends UiPart<Region> {
     public static final String ERROR_STYLE_CLASS = "error";
     private static final String FXML = "CommandBox.fxml";
 
+    private final UserInputHistory userInputHistory;
     private final CommandExecutor commandExecutor;
 
     @FXML
@@ -25,9 +28,24 @@ public class CommandBox extends UiPart<Region> {
      */
     public CommandBox(CommandExecutor commandExecutor) {
         super(FXML);
+        userInputHistory = new UserInputHistory();
         this.commandExecutor = commandExecutor;
         // calls #setStyleToDefault() whenever there is a change to the text of the command box.
         commandTextField.textProperty().addListener((unused1, unused2, unused3) -> setStyleToDefault());
+    }
+
+    /**
+     * Handles the Up or Down key pressed event.
+     */
+    @FXML
+    private void handleKeyPressed(KeyEvent event) {
+        if (event.getCode() == KeyCode.UP) {
+            String prevInput = userInputHistory.getPreviousInput();
+            commandTextField.setText(prevInput);
+        } else if (event.getCode() == KeyCode.DOWN) {
+            String nextInput = userInputHistory.getNextInput();
+            commandTextField.setText(nextInput);
+        }
     }
 
     /**
@@ -35,6 +53,7 @@ public class CommandBox extends UiPart<Region> {
      */
     @FXML
     private void handleCommandEntered() {
+        userInputHistory.addToHistory(commandTextField.getText());
         try {
             commandExecutor.execute(commandTextField.getText());
             commandTextField.setText("");

--- a/src/main/java/seedu/address/ui/UserInputHistory.java
+++ b/src/main/java/seedu/address/ui/UserInputHistory.java
@@ -1,0 +1,54 @@
+package seedu.address.ui;
+
+import java.util.LinkedList;
+import java.util.ListIterator;
+
+/**
+ * Stores past user inputs within the session.
+ */
+public class UserInputHistory {
+
+    private final LinkedList<String> inputHistory;
+
+    private ListIterator<String> inputHistoryIterator;
+
+    /**
+     * Instantiates an instance of {@code UserInputHistory} with an empty list and its iterator.
+     */
+    public UserInputHistory() {
+        this.inputHistory = new LinkedList<>();
+        this.inputHistoryIterator = inputHistory.listIterator(inputHistory.size());
+    }
+
+    /**
+     * Gets the input before the input the user navigated to in the input history.
+     * Returns empty String if there is no previous input.
+     */
+    public String getPreviousInput() {
+        if (inputHistoryIterator.hasPrevious()) {
+            return inputHistoryIterator.previous();
+        }
+        return "";
+    }
+
+    /**
+     * Gets the input after the input the user navigated to in the input history.
+     * Returns empty String if there is no input after the current input.
+     */
+    public String getNextInput() {
+        if (inputHistoryIterator.hasNext()) {
+            return inputHistoryIterator.next();
+        }
+        return "";
+    }
+
+    /**
+     * Adds the input entered by the user into the input history.
+     */
+    public void addToHistory(String userInput) {
+        inputHistoryIterator = null;
+        inputHistory.add(userInput);
+        inputHistoryIterator = inputHistory.listIterator(inputHistory.size());
+    }
+
+}

--- a/src/main/java/seedu/address/ui/UserInputHistory.java
+++ b/src/main/java/seedu/address/ui/UserInputHistory.java
@@ -1,6 +1,7 @@
 package seedu.address.ui;
 
 import java.util.LinkedList;
+import java.util.List;
 import java.util.ListIterator;
 
 /**
@@ -13,11 +14,25 @@ public class UserInputHistory {
     private ListIterator<String> inputHistoryIterator;
 
     /**
-     * Instantiates an instance of {@code UserInputHistory} with an empty list and its iterator.
+     * Initialises an instance of {@code UserInputHistory} with an empty list and its iterator.
      */
     public UserInputHistory() {
         this.inputHistory = new LinkedList<>();
         this.inputHistoryIterator = inputHistory.listIterator(inputHistory.size());
+    }
+
+    /**
+     * Gets the input history list. Should only be used for tests.
+     */
+    List<String> getHistoryList() {
+        return inputHistory;
+    }
+
+    /**
+     * Gets the history list iterator. Should only be used for tests.
+     */
+    ListIterator<String> getListIterator() {
+        return inputHistoryIterator;
     }
 
     /**

--- a/src/main/resources/text/helpForAllCommands.txt
+++ b/src/main/resources/text/helpForAllCommands.txt
@@ -10,7 +10,7 @@ contact sort                Sorts contact list                                  
 
 Archive commands
 ----------------------
-archive add                 Sends a contact to the archive                              contact archive INDEX
+archive add                 Sends a contact to the archive                              archive add INDEX
 archive list                Lists all archived contacts                                 archive list
 archive remove              Removes a contact from the archive                          archive remove INDEX
 

--- a/src/main/resources/view/CommandBox.fxml
+++ b/src/main/resources/view/CommandBox.fxml
@@ -4,6 +4,6 @@
 <?import javafx.scene.layout.StackPane?>
 
 <StackPane styleClass="stack-pane" xmlns="http://javafx.com/javafx/8" xmlns:fx="http://javafx.com/fxml/1">
-  <TextField fx:id="commandTextField" onAction="#handleCommandEntered" promptText="Enter command here..."/>
+  <TextField fx:id="commandTextField" onKeyPressed="#handleKeyPressed" onAction="#handleCommandEntered" promptText="Enter command here..."/>
 </StackPane>
 

--- a/src/test/java/seedu/address/ui/UserInputHistoryTest.java
+++ b/src/test/java/seedu/address/ui/UserInputHistoryTest.java
@@ -1,0 +1,57 @@
+package seedu.address.ui;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.LinkedList;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * Contains unit tests for {@code UserInputHistory}.
+ */
+public class UserInputHistoryTest {
+
+    @Test
+    public void addToHistory_success() {
+        String testInput = "test input";
+        UserInputHistory inputHistoryUnit = new UserInputHistory();
+        inputHistoryUnit.addToHistory(testInput);
+
+        LinkedList<String> expectedHistoryList = new LinkedList<>();
+        expectedHistoryList.add(testInput);
+
+        assertEquals(inputHistoryUnit.getHistoryList(), expectedHistoryList);
+    }
+
+    @Test
+    public void getPreviousInput_noPreviousInput_returnsEmptyString() {
+        UserInputHistory inputHistoryUnit = new UserInputHistory();
+        assertEquals(inputHistoryUnit.getPreviousInput(), "");
+    }
+
+    @Test
+    public void getPreviousInput_hasPreviousInput_success() {
+        String testInput = "test input";
+        UserInputHistory inputHistoryUnit = new UserInputHistory();
+        inputHistoryUnit.addToHistory(testInput);
+
+        assertEquals(inputHistoryUnit.getPreviousInput(), testInput);
+    }
+
+    @Test
+    public void getNextInput_noNextInput_returnsEmptyString() {
+        UserInputHistory inputHistoryUnit = new UserInputHistory();
+        assertEquals(inputHistoryUnit.getNextInput(), "");
+    }
+
+    @Test
+    public void getNextInput_hasNextInput_success() {
+        String testInput = "test input";
+        UserInputHistory inputHistoryUnit = new UserInputHistory();
+        inputHistoryUnit.addToHistory(testInput);
+        inputHistoryUnit.getListIterator().previous();
+
+        assertEquals(inputHistoryUnit.getNextInput(), testInput);
+    }
+
+}


### PR DESCRIPTION
Closes #132.

**New features/changes**
- Implement navigating user input history on the command box. Pressing the up key while on the command box gets the previous input, while pressing the down key gets the next input. If there is no previous or next input, the command box becomes empty.
- Add assertions to the archive add and remove commands.

**Implementations**
- Introduce a new class `UserInputHistory` to store all user inputs within the session. User inputs are stored in a `LinkedList`, and its `ListIterator` is used to navigate between inputs. Whenever the user enters a command, add the input to the `userInputHistory` of the command box and reset its iterator.

**Possible improvements**
- Write user inputs to a storage file so that the user can access inputs from previous sessions.
- Improve input history navigation (Pressing down after up returns the same input by the `ListIterator` navigation logic).

**Testing**
- Add unit tests for the `UserInputHistory` class.

**Demo**
![stonksbook_up_down_demo](https://user-images.githubusercontent.com/65291543/96704720-f92f2180-13c6-11eb-8dc8-2d75a5cac157.gif)
