### PR TITLE
Refactor storage of Meeting, Reminder to hold personId rather than the entire person 

### DIFF
--- a/src/main/java/seedu/address/model/AddressBook.java
+++ b/src/main/java/seedu/address/model/AddressBook.java
@@ -148,7 +148,8 @@ public class AddressBook implements ReadOnlyAddressBook {
     }
 
     /**
-     * Replaces the given person {@code target} in the list with {@code editedPerson}.
+     * Replaces the given person {@code target} in the list with {@code editedPerson}. This change will also
+     * propagate to all associated meetings and reminders.
      * {@code target} must exist in the address book.
      * The person identity of {@code editedPerson} must not be the same as another existing person in the address book.
      */
@@ -159,6 +160,9 @@ public class AddressBook implements ReadOnlyAddressBook {
         for (Tag t : editedPerson.getTags()) {
             contactTags.add(t);
         }
+
+        meetings.updateMeetingsWithContact(editedPerson);
+        reminders.updateRemindersWithContact(editedPerson);
     }
 
     /**

--- a/src/main/java/seedu/address/model/meeting/Meeting.java
+++ b/src/main/java/seedu/address/model/meeting/Meeting.java
@@ -48,6 +48,10 @@ public class Meeting implements Comparable<Meeting> {
         return this.person;
     }
 
+    public int getPersonId() {
+        return this.person.getId();
+    }
+
     public Message getMessage() {
         return this.message;
     }

--- a/src/main/java/seedu/address/model/meeting/UniqueMeetingList.java
+++ b/src/main/java/seedu/address/model/meeting/UniqueMeetingList.java
@@ -81,6 +81,26 @@ public class UniqueMeetingList implements Iterable<Meeting> {
         }
     }
 
+    /**
+     * Updates the contact details of all meetings within the list that are associated with {@code contact}.
+     * This is necessary when the contact details has been updated, but the meeting is still storing an outdated
+     * version of the contact details.
+     *
+     * @param contact The contact whose information has been updated.
+     */
+    public void updateMeetingsWithContact(Person contact) {
+        requireNonNull(contact);
+        List<Meeting> meetingsToUpdate =
+                internalList.stream().filter(meeting -> meeting.getPersonId() == contact.getId())
+                        .collect(Collectors.toList());
+
+        for (Meeting meeting : meetingsToUpdate) {
+            Meeting updatedMeeting =
+                    new Meeting(contact, meeting.getMessage(), meeting.getStartDate(), meeting.getDuration());
+            this.setMeeting(meeting, updatedMeeting);
+        }
+    }
+
     public void setMeetings(UniqueMeetingList replacement) {
         requireNonNull(replacement);
         internalList.setAll(replacement.internalList);

--- a/src/main/java/seedu/address/model/reminder/Reminder.java
+++ b/src/main/java/seedu/address/model/reminder/Reminder.java
@@ -59,6 +59,10 @@ public class Reminder implements Comparable<Reminder> {
         return this.person;
     }
 
+    public int getPersonId() {
+        return this.person.getId();
+    }
+
     public Message getMessage() {
         return this.message;
     }

--- a/src/main/java/seedu/address/model/reminder/UniqueReminderList.java
+++ b/src/main/java/seedu/address/model/reminder/UniqueReminderList.java
@@ -71,6 +71,26 @@ public class UniqueReminderList implements Iterable<Reminder> {
         }
     }
 
+    /**
+     * Updates the contact details of all reminders within the list that are associated with {@code contact}.
+     * This is necessary when the contact details has been updated, but the reminder is still storing an outdated
+     * version of the contact details.
+     *
+     * @param contact The contact whose information has been updated.
+     */
+    public void updateRemindersWithContact(Person contact) {
+        requireNonNull(contact);
+        List<Reminder> remindersToUpdate =
+                internalList.stream().filter(reminder -> reminder.getPersonId() == contact.getId())
+                        .collect(Collectors.toList());
+
+        for (Reminder reminder : remindersToUpdate) {
+            Reminder updatedReminder =
+                    new Reminder(contact, reminder.getMessage(), reminder.getScheduledDate(), reminder.isCompleted());
+            this.setReminder(reminder, updatedReminder);
+        }
+    }
+
     public void setReminders(UniqueReminderList replacement) {
         requireNonNull(replacement);
         internalList.setAll(replacement.internalList);

--- a/src/main/java/seedu/address/storage/JsonAdaptedReminder.java
+++ b/src/main/java/seedu/address/storage/JsonAdaptedReminder.java
@@ -4,6 +4,7 @@ import static seedu.address.commons.core.Messages.MESSAGE_INVALID_DATETIME;
 
 import java.time.LocalDateTime;
 import java.time.format.DateTimeParseException;
+import java.util.List;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -19,8 +20,9 @@ import seedu.address.model.reminder.Reminder;
 class JsonAdaptedReminder {
 
     public static final String MISSING_FIELD_MESSAGE_FORMAT = "Reminder's %s field is missing!";
+    public static final String INVALID_CONTACT_ID = "Invalid contact specified";
 
-    private final JsonAdaptedPerson person;
+    private final Integer personId;
     private final String message;
     // Serialised and stored in ISO-8601 format
     private final String scheduledDate;
@@ -30,11 +32,11 @@ class JsonAdaptedReminder {
      * Constructs a {@code JsonAdaptedReminder} with the given reminder details.
      */
     @JsonCreator
-    public JsonAdaptedReminder(@JsonProperty("person") JsonAdaptedPerson person,
+    public JsonAdaptedReminder(@JsonProperty("personId") Integer personId,
                                @JsonProperty("message") String message,
                                @JsonProperty("scheduledDate") String scheduledDate,
                                @JsonProperty("completed") Boolean completed) {
-        this.person = person;
+        this.personId = personId;
         this.message = message;
         this.scheduledDate = scheduledDate;
         this.completed = completed;
@@ -44,22 +46,30 @@ class JsonAdaptedReminder {
      * Converts a given {@code Reminder} into this class for Jackson use.
      */
     public JsonAdaptedReminder(Reminder source) {
-        this.person = new JsonAdaptedPerson(source.getPerson());
+        this.personId = source.getPersonId();
         this.message = source.getMessage().message;
         this.scheduledDate = source.getScheduledDate().toString();
         this.completed = source.isCompleted();
     }
 
+
     /**
      * Converts this Jackson-friendly adapted reminder object into the model's {@code Reminder} object.
      *
-     * @throws IllegalValueException if there were any data constraints violated in the adapted reminder.
+     * @param personList The list of all persons currently in StonksBook
+     * @return The @{Reminder} object converted from the Jackson-friendly adapted reminder object.
+     * @throws IllegalValueException IllegalValueException if there were any data constraints violated in the adapted
+     *                               reminder.
      */
-    public Reminder toModelType() throws IllegalValueException {
-        if (this.person == null) {
+    public Reminder toModelType(List<Person> personList) throws IllegalValueException {
+        if (this.personId == null) {
             throw new IllegalValueException(String.format(MISSING_FIELD_MESSAGE_FORMAT, Person.class.getSimpleName()));
         }
-        final Person person = this.person.toModelType();
+        final Person associatedPerson = personList
+                .stream()
+                .filter(person -> person.getId().equals(this.personId))
+                .findFirst()
+                .orElseThrow(() -> new IllegalValueException(INVALID_CONTACT_ID));
 
         if (this.message == null) {
             throw new IllegalValueException(String.format(MISSING_FIELD_MESSAGE_FORMAT, "Message"));
@@ -77,6 +87,6 @@ class JsonAdaptedReminder {
             throw new IllegalValueException(MESSAGE_INVALID_DATETIME);
         }
 
-        return new Reminder(person, message, scheduledDate, this.completed == null ? false : completed);
+        return new Reminder(associatedPerson, message, scheduledDate, this.completed == null ? false : completed);
     }
 }

--- a/src/main/java/seedu/address/storage/JsonSerializableAddressBook.java
+++ b/src/main/java/seedu/address/storage/JsonSerializableAddressBook.java
@@ -97,7 +97,7 @@ class JsonSerializableAddressBook {
         addressBook.sortTags();
 
         for (JsonAdaptedMeeting jsonAdaptedMeeting : meetings) {
-            Meeting meeting = jsonAdaptedMeeting.toModelType();
+            Meeting meeting = jsonAdaptedMeeting.toModelType(addressBook.getPersonList());
             if (addressBook.hasMeeting(meeting)) {
                 throw new IllegalValueException(MESSAGE_DUPLICATE_MEETING);
             }

--- a/src/main/java/seedu/address/storage/JsonSerializableAddressBook.java
+++ b/src/main/java/seedu/address/storage/JsonSerializableAddressBook.java
@@ -105,7 +105,7 @@ class JsonSerializableAddressBook {
         }
 
         for (JsonAdaptedReminder jsonAdaptedReminder : reminders) {
-            Reminder reminder = jsonAdaptedReminder.toModelType();
+            Reminder reminder = jsonAdaptedReminder.toModelType(addressBook.getPersonList());
             if (addressBook.hasReminder(reminder)) {
                 throw new IllegalValueException(MESSAGE_DUPLICATE_REMINDER);
             }

--- a/src/test/data/JsonAddressBookStorageTest/invalidAndValidMeetingAddressBook.json
+++ b/src/test/data/JsonAddressBookStorageTest/invalidAndValidMeetingAddressBook.json
@@ -1,35 +1,29 @@
 {
-  "persons": [],
+  "persons": [
+    {
+      "id": 1,
+      "name": "Alice Pauline",
+      "phone": "94351253",
+      "email": "alice@example.com",
+      "address": "123, Jurong West Ave 6, #08-111",
+      "tagged": [
+        "friends"
+      ],
+      "archived": false
+    }
+  ],
   "contactTags": [],
   "saleTags": [],
   "reminders": [],
   "meetings": [
     {
-      "person": {
-        "name": "Alice Pauline",
-        "phone": "94351253",
-        "email": "alice@example.com",
-        "address": "123, Jurong West Ave 6, #08-111",
-        "tagged": [
-          "friends"
-        ],
-        "archived": false
-      },
+      "personId": 1,
       "message": "Lunch with Alice",
       "startDate": "2020-10-30T15:19",
       "duration": "PT30M"
     },
     {
-      "person": {
-        "name": "Alice Pauline",
-        "phone": "94351253",
-        "email": "alice@example.com",
-        "address": "123, Jurong West Ave 6, #08-111",
-        "tagged": [
-          "friends"
-        ],
-        "archived": false
-      },
+      "personId": 1,
       "message": "Lunch with Alice",
       "startDate": "2020-10-30T15:19",
       "duration": "PT30.5M"

--- a/src/test/data/JsonAddressBookStorageTest/invalidAndValidReminderAddressBook.json
+++ b/src/test/data/JsonAddressBookStorageTest/invalidAndValidReminderAddressBook.json
@@ -1,35 +1,39 @@
 {
   "persons": [
+    {
+      "id": 1,
+      "name": "Alice Pauline",
+      "phone": "94351253",
+      "email": "alice@example.com",
+      "address": "123, Jurong West Ave 6, #08-111",
+      "tagged": [
+        "friends"
+      ],
+      "archived": false
+    },
+    {
+      "id": 2,
+      "name": "Benson Meier",
+      "phone": "98765432",
+      "email": "johnd@example.com",
+      "address": "311, Clementi Ave 2, #02-25",
+      "tagged": [
+        "owesMoney",
+        "friends"
+      ],
+      "archived": false
+    }
   ],
   "contactTags": [],
   "saleTags": [],
   "reminders": [
     {
-      "person": {
-        "name": "Alice Pauline",
-        "phone": "94351253",
-        "email": "alice@example.com",
-        "address": "123, Jurong West Ave 6, #08-111",
-        "tagged": [
-          "friends"
-        ],
-        "archived": false
-      },
+      "personId": 1,
       "message": "Call Alice",
       "scheduledDate": "2020-10-30T30:19"
     },
     {
-      "person": {
-        "name": "Benson Meier",
-        "phone": "98765432",
-        "email": "johnd@example.com",
-        "address": "311, Clementi Ave 2, #02-25",
-        "tagged": [
-          "owesMoney",
-          "friends"
-        ],
-        "archived": false
-      },
+      "personId": 2,
       "message": "Email Benson",
       "scheduledDate": "2018-12-20T12:00"
     }

--- a/src/test/data/JsonAddressBookStorageTest/invalidDateInMeetingAddressBook.json
+++ b/src/test/data/JsonAddressBookStorageTest/invalidDateInMeetingAddressBook.json
@@ -1,20 +1,23 @@
 {
-  "persons": [],
+  "persons": [
+    {
+      "id": 1,
+      "name": "Alice Pauline",
+      "phone": "94351253",
+      "email": "alice@example.com",
+      "address": "123, Jurong West Ave 6, #08-111",
+      "tagged": [
+        "friends"
+      ],
+      "archived": false
+    }
+  ],
   "contactTags": [],
   "saleTags": [],
   "reminders": [],
   "meetings": [
     {
-      "person": {
-        "name": "Alice Pauline",
-        "phone": "94351253",
-        "email": "alice@example.com",
-        "address": "123, Jurong West Ave 6, #08-111",
-        "tagged": [
-          "friends"
-        ],
-        "archived": false
-      },
+      "personId": 1,
       "message": "Lunch with Alice",
       "startDate": "2020/10/30 3:19PM",
       "duration": "PT30M"

--- a/src/test/data/JsonAddressBookStorageTest/invalidDateInReminderAddressBook.json
+++ b/src/test/data/JsonAddressBookStorageTest/invalidDateInReminderAddressBook.json
@@ -1,19 +1,22 @@
 {
-  "persons": [],
+  "persons": [
+    {
+      "id": 1,
+      "name": "Alice Pauline",
+      "phone": "94351253",
+      "email": "alice@example.com",
+      "address": "123, Jurong West Ave 6, #08-111",
+      "tagged": [
+        "friends"
+      ],
+      "archived": false
+    }
+  ],
   "contactTags": [],
   "saleTags": [],
   "reminders": [
     {
-      "person": {
-        "name": "Alice Pauline",
-        "phone": "94351253",
-        "email": "alice@example.com",
-        "address": "123, Jurong West Ave 6, #08-111",
-        "tagged": [
-          "friends"
-        ],
-        "archived": false
-      },
+      "personId": 1,
       "message": "Call Alice",
       "scheduledDate": "2020-10-30T30:19"
     }

--- a/src/test/data/JsonAddressBookStorageTest/invalidPersonInMeetingAddressBook.json
+++ b/src/test/data/JsonAddressBookStorageTest/invalidPersonInMeetingAddressBook.json
@@ -1,20 +1,23 @@
 {
-  "persons": [],
+  "persons": [
+    {
+      "id": 1,
+      "name": "Alice@Pauline!!",
+      "phone": "94351253",
+      "email": "alice@example.com",
+      "address": "123, Jurong West Ave 6, #08-111",
+      "tagged": [
+        "friends"
+      ],
+      "archived": false
+    }
+  ],
   "contactTags": [],
   "saleTags": [],
   "reminders": [],
   "meetings": [
     {
-      "person": {
-        "name": "Alice@Pauline!!",
-        "phone": "94351253",
-        "email": "alice@example.com",
-        "address": "123, Jurong West Ave 6, #08-111",
-        "tagged": [
-          "friends"
-        ],
-        "archived": false
-      },
+      "personId": 1,
       "message": "Lunch with Alice",
       "startDate": "2020-10-30T15:19",
       "duration": "PT120M"

--- a/src/test/data/JsonAddressBookStorageTest/invalidPersonInReminderAddressBook.json
+++ b/src/test/data/JsonAddressBookStorageTest/invalidPersonInReminderAddressBook.json
@@ -1,20 +1,22 @@
 {
   "persons": [
+    {
+      "id": 1,
+      "name": "Alice P@uline",
+      "phone": "94351253",
+      "email": "alice@example.com",
+      "address": "123, Jurong West Ave 6, #08-111",
+      "tagged": [
+        "friends"
+      ],
+      "archived": false
+    }
   ],
   "contactTags": [],
   "saleTags": [],
   "reminders": [
     {
-      "person": {
-        "name": "Alice P@uline",
-        "phone": "94351253",
-        "email": "alice@example.com",
-        "address": "123, Jurong West Ave 6, #08-111",
-        "tagged": [
-          "friends"
-        ],
-        "archived": false
-      },
+      "personId": 1,
       "message": "Call Alice",
       "scheduledDate": "2020-10-30T13:19"
     }

--- a/src/test/data/JsonSerializableAddressBookTest/duplicateMeetingsAddressBook.json
+++ b/src/test/data/JsonSerializableAddressBookTest/duplicateMeetingsAddressBook.json
@@ -1,45 +1,35 @@
 {
-  "persons": [],
+  "persons": [
+    {
+      "id": 1,
+      "name": "Alice Pauline",
+      "phone": "94351253",
+      "email": "alice@example.com",
+      "address": "123, Jurong West Ave 6, #08-111",
+      "tagged": [
+        "friends"
+      ],
+      "remark": "Likes chocolates",
+      "archived": false,
+      "totalSalesAmount": "0.80"
+    }
+  ],
   "contactTags": [],
   "saleTags": [],
   "reminders": [],
   "meetings": [
     {
-      "person": {
-        "id": 1,
-        "name": "Alice Pauline",
-        "phone": "94351253",
-        "email": "alice@example.com",
-        "address": "123, Jurong West Ave 6, #08-111",
-        "tagged": [
-          "friends"
-        ],
-        "remark": "Likes chocolates",
-        "archived": false,
-        "totalSalesAmount" : "0.00"
-      },
+      "personId": 1,
       "message": "Lunch with Alice",
       "startDate": "2020-10-30T15:19",
       "duration": "PT30M"
     },
     {
-      "person": {
-        "id": 1,
-        "name": "Alice Pauline",
-        "phone": "94351253",
-        "email": "alice@example.com",
-        "address": "123, Jurong West Ave 6, #08-111",
-        "tagged": [
-          "friends"
-        ],
-        "remark": "Likes chocolates",
-        "archived": false,
-        "totalSalesAmount" : "0.00"
-      },
+      "personId": 1,
       "message": "Lunch with Alice",
       "startDate": "2020-10-30T15:19",
       "duration": "PT30M"
     }
   ],
-  "sales" : []
+  "sales": []
 }

--- a/src/test/data/JsonSerializableAddressBookTest/duplicateReminderAddressBook.json
+++ b/src/test/data/JsonSerializableAddressBookTest/duplicateReminderAddressBook.json
@@ -1,39 +1,29 @@
 {
-  "persons": [],
+  "persons": [
+    {
+      "id": 1,
+      "name": "Alice Pauline",
+      "phone": "94351253",
+      "email": "alice@example.com",
+      "address": "123, Jurong West Ave 6, #08-111",
+      "tagged": [
+        "friends"
+      ],
+      "remark": "Likes chocolates",
+      "archived": false,
+      "totalSalesAmount": "0.80"
+    }
+  ],
   "contactTags": [],
   "saleTags": [],
   "reminders": [
     {
-      "person": {
-        "id": 1,
-        "name": "Alice Pauline",
-        "phone": "94351253",
-        "email": "alice@example.com",
-        "address": "123, Jurong West Ave 6, #08-111",
-        "tagged": [
-          "friends"
-        ],
-        "remark": "Likes chocolates",
-        "archived": false,
-        "totalSalesAmount" : "0.80"
-      },
+      "personId": 1,
       "message": "Call Alice",
       "scheduledDate": "2020-10-30T15:19"
     },
     {
-      "person": {
-        "id": 1,
-        "name": "Alice Pauline",
-        "phone": "94351253",
-        "email": "alice@example.com",
-        "address": "123, Jurong West Ave 6, #08-111",
-        "tagged": [
-          "friends"
-        ],
-        "remark": "Likes chocolates",
-        "archived": false,
-        "totalSalesAmount" : "0.80"
-      },
+      "personId": 1,
       "message": "Call Alice",
       "scheduledDate": "2020-10-30T15:19"
     }

--- a/src/test/data/JsonSerializableAddressBookTest/invalidDateInMeetingAddressBook.json
+++ b/src/test/data/JsonSerializableAddressBookTest/invalidDateInMeetingAddressBook.json
@@ -1,23 +1,25 @@
 {
-  "persons": [],
+  "persons": [
+    {
+      "id": 1,
+      "name": "Alice Pauline",
+      "phone": "94351253",
+      "email": "alice@example.com",
+      "address": "123, Jurong West Ave 6, #08-111",
+      "tagged": [
+        "friends"
+      ],
+      "remark": "Likes chocolates",
+      "archived": false,
+      "totalSalesAmount": "0.80"
+    }
+  ],
   "contactTags": [],
   "saleTags": [],
   "reminders": [],
   "meetings": [
     {
-      "person": {
-        "id": 1,
-        "name": "Alice Pauline",
-        "phone": "94351253",
-        "email": "alice@example.com",
-        "address": "123, Jurong West Ave 6, #08-111",
-        "tagged": [
-          "friends"
-        ],
-        "remark": "Likes chocolates",
-        "archived": false,
-        "totalSalesAmount" : "0.80"
-      },
+      "personId": 1,
       "message": "Lunch with Alice",
       "startDate": "2020/10/30 3:19PM",
       "duration": "PT30M"

--- a/src/test/data/JsonSerializableAddressBookTest/invalidDurationInMeetingAddressBook.json
+++ b/src/test/data/JsonSerializableAddressBookTest/invalidDurationInMeetingAddressBook.json
@@ -1,23 +1,25 @@
 {
-  "persons": [],
+  "persons": [
+    {
+      "id": 1,
+      "name": "Alice Pauline",
+      "phone": "94351253",
+      "email": "alice@example.com",
+      "address": "123, Jurong West Ave 6, #08-111",
+      "tagged": [
+        "friends"
+      ],
+      "remark": "Likes chocolates",
+      "archived": false,
+      "totalSalesAmount": "0.80"
+    }
+  ],
   "contactTags": [],
   "saleTags": [],
   "reminders": [],
   "meetings": [
     {
-      "person": {
-        "id": 1,
-        "name": "Alice Pauline",
-        "phone": "94351253",
-        "email": "alice@example.com",
-        "address": "123, Jurong West Ave 6, #08-111",
-        "tagged": [
-          "friends"
-        ],
-        "remark": "Likes chocolates",
-        "archived": false,
-        "totalSalesAmount" : "0.80"
-      },
+      "personId": 1,
       "message": "Lunch with Alice",
       "startDate": "2020-10-30T15:19",
       "duration": "PT30.5M"

--- a/src/test/data/JsonSerializableAddressBookTest/invalidPersonInMeetingAddressBook.json
+++ b/src/test/data/JsonSerializableAddressBookTest/invalidPersonInMeetingAddressBook.json
@@ -1,23 +1,25 @@
 {
-  "persons": [],
+  "persons": [
+    {
+      "id": 1,
+      "name": "Alice@Pauline!!",
+      "phone": "94351253",
+      "email": "alice@example.com",
+      "address": "123, Jurong West Ave 6, #08-111",
+      "tagged": [
+        "friends"
+      ],
+      "remark": "Likes chocolates",
+      "archived": false,
+      "totalSalesAmount": "0.80"
+    }
+  ],
   "contactTags": [],
   "saleTags": [],
   "reminders": [],
   "meetings": [
     {
-      "person": {
-        "id": 1,
-        "name": "Alice@Pauline!!",
-        "phone": "94351253",
-        "email": "alice@example.com",
-        "address": "123, Jurong West Ave 6, #08-111",
-        "tagged": [
-          "friends"
-        ],
-        "remark": "Likes chocolates",
-        "archived": false,
-        "totalSalesAmount" : "0.80"
-      },
+      "personId": 1,
       "message": "Lunch with Alice",
       "startDate": "2020-10-30T15:19",
       "duration": "PT120M"

--- a/src/test/data/JsonSerializableAddressBookTest/invalidReminderAddressBook.json
+++ b/src/test/data/JsonSerializableAddressBookTest/invalidReminderAddressBook.json
@@ -1,22 +1,24 @@
 {
-  "persons": [],
+  "persons": [
+    {
+      "id": 1,
+      "name": "Alice Pauline",
+      "phone": "94351253",
+      "email": "alice@example.com",
+      "address": "123, Jurong West Ave 6, #08-111",
+      "tagged": [
+        "friends"
+      ],
+      "remark": "Likes chocolates",
+      "archived": false,
+      "totalSalesAmount": "0.80"
+    }
+  ],
   "contactTags": [],
   "saleTags": [],
   "reminders": [
     {
-      "person": {
-        "id": 1,
-        "name": "Alice Pauline",
-        "phone": "94351253",
-        "email": "alice@example.com",
-        "address": "123, Jurong West Ave 6, #08-111",
-        "tagged": [
-          "friends"
-        ],
-        "remark": "Likes chocolates",
-        "archived": false,
-        "totalSalesAmount" : "0.80"
-      },
+      "personId": 1,
       "scheduledDate": "2020-10-30T15:19"
     }
   ],

--- a/src/test/data/JsonSerializableAddressBookTest/typicalAddressBook.json
+++ b/src/test/data/JsonSerializableAddressBookTest/typicalAddressBook.json
@@ -110,49 +110,17 @@
   "saleTags": [],
   "reminders": [
     {
-      "person": {
-        "id": 1,
-        "name": "Alice Pauline",
-        "phone": "94351253",
-        "email": "alice@example.com",
-        "address": "123, Jurong West Ave 6, #08-111",
-        "tagged": [
-          "friends"
-        ],
-        "remark": "Likes chocolates",
-        "totalSalesAmount" : "0.80"
-      },
+      "personId": 1,
       "message": "Call Alice",
       "scheduledDate": "2020-10-30T15:19"
     },
     {
-      "person": {
-        "id": 2,
-        "name": "Benson Meier",
-        "phone": "98765432",
-        "email": "johnd@example.com",
-        "address": "311, Clementi Ave 2, #02-25",
-        "tagged": [
-          "owesMoney",
-          "friends"
-        ],
-        "remark": "Owes me $10",
-        "totalSalesAmount" : "35.00"
-      },
+      "personId": 2,
       "message": "Email Benson",
       "scheduledDate": "2018-12-20T12:00"
     },
     {
-      "person": {
-        "id": 3,
-        "name": "Carl Kurz",
-        "phone": "95352563",
-        "email": "heinz@example.com",
-        "address": "wall street",
-        "tagged": [],
-        "remark": "",
-        "totalSalesAmount" : "2001.00"
-      },
+      "personId": 3,
       "message": "Set meeting with Carl",
       "scheduledDate": "2020-12-20T12:12"
     }

--- a/src/test/data/JsonSerializableAddressBookTest/typicalAddressBook.json
+++ b/src/test/data/JsonSerializableAddressBookTest/typicalAddressBook.json
@@ -159,54 +159,19 @@
   ],
   "meetings": [
     {
-      "person": {
-        "id": 1,
-        "name": "Alice Pauline",
-        "phone": "94351253",
-        "email": "alice@example.com",
-        "address": "123, Jurong West Ave 6, #08-111",
-        "tagged": [
-          "friends"
-        ],
-        "remark": "Likes chocolates",
-        "archived": false,
-        "totalSalesAmount" : "0.80"
-      },
+      "personId": 1,
       "message": "Meet Alice to discuss pricing",
       "startDate": "2020-10-30T15:19",
       "duration": "PT60M"
     },
     {
-      "person": {
-        "id": 2,
-        "name": "Benson Meier",
-        "phone": "98765432",
-        "email": "johnd@example.com",
-        "address": "311, Clementi Ave 2, #02-25",
-        "tagged": [
-          "owesMoney",
-          "friends"
-        ],
-        "remark": "Owes me $10",
-        "archived": false,
-        "totalSalesAmount" : "35.00"
-      },
+      "personId": 2,
       "message": "Present proposal to Benson",
       "startDate": "2018-12-20T12:00",
       "duration": "PT90M"
     },
     {
-      "person": {
-        "id": 3,
-        "name": "Carl Kurz",
-        "phone": "95352563",
-        "email": "heinz@example.com",
-        "address": "wall street",
-        "tagged": [],
-        "remark": "",
-        "archived": false,
-        "totalSalesAmount": "2001.00"
-      },
+      "personId": 3,
       "message": "Lunch with Carl",
       "startDate": "2020-12-21T12:12",
       "duration": "PT45M"

--- a/src/test/java/seedu/address/model/meeting/UniqueMeetingListTest.java
+++ b/src/test/java/seedu/address/model/meeting/UniqueMeetingListTest.java
@@ -7,6 +7,7 @@ import static seedu.address.testutil.Assert.assertThrows;
 import static seedu.address.testutil.meeting.TypicalMeetings.MEET_ALICE;
 import static seedu.address.testutil.meeting.TypicalMeetings.PRESENT_PROPOSAL_BENSON;
 import static seedu.address.testutil.person.TypicalPersons.ALICE;
+import static seedu.address.testutil.person.TypicalPersons.FIONA;
 
 import java.time.Duration;
 import java.time.LocalDateTime;
@@ -21,6 +22,8 @@ import org.junit.jupiter.api.Test;
 import seedu.address.model.Message;
 import seedu.address.model.meeting.exceptions.DuplicateMeetingException;
 import seedu.address.model.meeting.exceptions.MeetingNotFoundException;
+import seedu.address.model.person.Person;
+import seedu.address.testutil.person.PersonBuilder;
 
 
 public class UniqueMeetingListTest {
@@ -111,6 +114,46 @@ public class UniqueMeetingListTest {
         uniqueMeetingList.removeMeetingsWithContact(ALICE);
 
         UniqueMeetingList expectedUniqueMeetingList = new UniqueMeetingList();
+        expectedUniqueMeetingList.add(PRESENT_PROPOSAL_BENSON);
+
+        assertEquals(expectedUniqueMeetingList, uniqueMeetingList);
+    }
+
+    @Test
+    public void updateMeetingsWithContact_contactWithMultipleMeetings_associatedMeetingsUpdated() {
+        uniqueMeetingList.add(MEET_ALICE);
+        uniqueMeetingList.add(PRESENT_PROPOSAL_BENSON);
+        Meeting secondMeetingWithAlice = new Meeting(ALICE, new Message("Second meeting with Alice"),
+                LocalDateTime.of(2021, 10, 30, 10, 19),
+                Duration.ofMinutes(60));
+        uniqueMeetingList.add(secondMeetingWithAlice);
+
+        Person aliceRenamedToAlicia = new PersonBuilder(ALICE).withName("Alicia Pauline").build();
+        uniqueMeetingList.updateMeetingsWithContact(aliceRenamedToAlicia);
+
+        UniqueMeetingList expectedUniqueMeetingList = new UniqueMeetingList();
+        Meeting meetAlicia = new Meeting(aliceRenamedToAlicia, MEET_ALICE.getMessage(), MEET_ALICE.getStartDate(),
+                MEET_ALICE.getDuration());
+        expectedUniqueMeetingList.add(meetAlicia);
+        expectedUniqueMeetingList.add(PRESENT_PROPOSAL_BENSON);
+        Meeting secondMeetingWithAlicia =
+                new Meeting(aliceRenamedToAlicia, secondMeetingWithAlice.getMessage(),
+                        secondMeetingWithAlice.getStartDate(),
+                        secondMeetingWithAlice.getDuration());
+        expectedUniqueMeetingList.add(secondMeetingWithAlicia);
+
+        assertEquals(expectedUniqueMeetingList, uniqueMeetingList);
+    }
+
+    @Test
+    public void updateMeetingsWithContact_contactNotAssociatedWithReminders_noChange() {
+        uniqueMeetingList.add(MEET_ALICE);
+        uniqueMeetingList.add(PRESENT_PROPOSAL_BENSON);
+
+        uniqueMeetingList.updateMeetingsWithContact(FIONA);
+
+        UniqueMeetingList expectedUniqueMeetingList = new UniqueMeetingList();
+        expectedUniqueMeetingList.add(MEET_ALICE);
         expectedUniqueMeetingList.add(PRESENT_PROPOSAL_BENSON);
 
         assertEquals(expectedUniqueMeetingList, uniqueMeetingList);

--- a/src/test/java/seedu/address/model/reminder/UniqueReminderListTest.java
+++ b/src/test/java/seedu/address/model/reminder/UniqueReminderListTest.java
@@ -5,6 +5,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.address.testutil.Assert.assertThrows;
 import static seedu.address.testutil.person.TypicalPersons.ALICE;
+import static seedu.address.testutil.person.TypicalPersons.FIONA;
 import static seedu.address.testutil.reminder.TypicalReminders.CALL_ALICE;
 import static seedu.address.testutil.reminder.TypicalReminders.EMAIL_BENSON;
 
@@ -16,8 +17,10 @@ import java.util.List;
 import org.junit.jupiter.api.Test;
 
 import seedu.address.model.Message;
+import seedu.address.model.person.Person;
 import seedu.address.model.reminder.exceptions.DuplicateReminderException;
 import seedu.address.model.reminder.exceptions.ReminderNotFoundException;
+import seedu.address.testutil.person.PersonBuilder;
 
 public class UniqueReminderListTest {
     private final UniqueReminderList uniqueReminderList = new UniqueReminderList();
@@ -93,6 +96,45 @@ public class UniqueReminderListTest {
 
         assertEquals(expectedUniqueReminderList, uniqueReminderList);
     }
+
+    @Test
+    public void updateRemindersWithContact_contactWithMultipleReminders_associatedRemindersUpdated() {
+        uniqueReminderList.add(CALL_ALICE);
+        uniqueReminderList.add(EMAIL_BENSON);
+        Reminder secondReminderWithAlice = new Reminder(ALICE, new Message("Second reminder with Alice"),
+                LocalDateTime.of(2021, 10, 30, 10, 19));
+        uniqueReminderList.add(secondReminderWithAlice);
+
+        Person aliceRenamedToAlicia = new PersonBuilder(ALICE).withName("Alicia Pauline").build();
+        uniqueReminderList.updateRemindersWithContact(aliceRenamedToAlicia);
+
+        UniqueReminderList expectedUniqueReminderList = new UniqueReminderList();
+        Reminder callAlicia =
+                new Reminder(aliceRenamedToAlicia, CALL_ALICE.getMessage(), CALL_ALICE.getScheduledDate());
+        expectedUniqueReminderList.add(callAlicia);
+        expectedUniqueReminderList.add(EMAIL_BENSON);
+        Reminder secondReminderWithAlicia =
+                new Reminder(aliceRenamedToAlicia, secondReminderWithAlice.getMessage(),
+                        secondReminderWithAlice.getScheduledDate());
+        expectedUniqueReminderList.add(secondReminderWithAlicia);
+
+        assertEquals(expectedUniqueReminderList, uniqueReminderList);
+    }
+
+    @Test
+    public void updateRemindersWithContact_contactNotAssociatedWithReminders_noChange() {
+        uniqueReminderList.add(CALL_ALICE);
+        uniqueReminderList.add(EMAIL_BENSON);
+
+        uniqueReminderList.updateRemindersWithContact(FIONA);
+
+        UniqueReminderList expectedUniqueReminderList = new UniqueReminderList();
+        expectedUniqueReminderList.add(CALL_ALICE);
+        expectedUniqueReminderList.add(EMAIL_BENSON);
+
+        assertEquals(expectedUniqueReminderList, uniqueReminderList);
+    }
+
 
     @Test
     public void setReminder_nullTargetReminder_throwsNullPointerException() {

--- a/src/test/java/seedu/address/storage/JsonAdaptedMeetingTest.java
+++ b/src/test/java/seedu/address/storage/JsonAdaptedMeetingTest.java
@@ -3,11 +3,16 @@ package seedu.address.storage;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_DATETIME;
 import static seedu.address.storage.JsonAdaptedMeeting.DESERIALIZING_DURATION_ERROR_MESSAGE;
+import static seedu.address.storage.JsonAdaptedMeeting.INVALID_CONTACT_ID;
 import static seedu.address.storage.JsonAdaptedMeeting.MISSING_FIELD_MESSAGE_FORMAT;
 import static seedu.address.testutil.Assert.assertThrows;
 import static seedu.address.testutil.meeting.TypicalMeetings.MEET_ALICE;
 import static seedu.address.testutil.person.TypicalPersons.ALICE;
 
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import seedu.address.commons.exceptions.IllegalValueException;
@@ -24,64 +29,79 @@ public class JsonAdaptedMeetingTest {
     private static final String VALID_DATE = "2020-10-30T15:19";
     private static final String VALID_DURATION_MINUTE = "PT1H40M";
 
-    @Test
-    public void toModelType_validMeetingDetails_returnsMeeting() throws Exception {
-        JsonAdaptedMeeting meeting = new JsonAdaptedMeeting(MEET_ALICE);
-        assertEquals(MEET_ALICE, meeting.toModelType());
+    private List<Person> personList = new ArrayList<>();
+
+    @BeforeEach
+    public void setUp() {
+        personList.add(ALICE);
     }
 
     @Test
-    public void toModelType_nullPerson_throwsIllegalValueException() {
+    public void toModelType_validMeetingDetails_returnsMeeting() throws Exception {
+        JsonAdaptedMeeting meeting = new JsonAdaptedMeeting(MEET_ALICE);
+        assertEquals(MEET_ALICE, meeting.toModelType(personList));
+    }
+
+    @Test
+    public void toModelType_nullPersonId_throwsIllegalValueException() {
         JsonAdaptedMeeting meeting =
-            new JsonAdaptedMeeting(null, VALID_MESSAGE, VALID_DATE, VALID_DURATION_MINUTE);
+                new JsonAdaptedMeeting(null, VALID_MESSAGE, VALID_DATE, VALID_DURATION_MINUTE);
         String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT, Person.class.getSimpleName());
-        assertThrows(IllegalValueException.class, expectedMessage, meeting::toModelType);
+        assertThrows(IllegalValueException.class, expectedMessage, () -> meeting.toModelType(personList));
+    }
+
+    @Test
+    public void toModelType_invalidPersonId_throwsIllegalValueException() {
+        JsonAdaptedMeeting meeting =
+                new JsonAdaptedMeeting(-134, VALID_MESSAGE, VALID_DATE, VALID_DURATION_MINUTE);
+        String expectedMessage = INVALID_CONTACT_ID;
+        assertThrows(IllegalValueException.class, expectedMessage, () -> meeting.toModelType(personList));
     }
 
     @Test
     public void toModelType_nullMessage_throwsIllegalValueException() {
-        JsonAdaptedMeeting meeting = new JsonAdaptedMeeting(VALID_PERSON, null, VALID_DATE,
-            VALID_DURATION_MINUTE);
+        JsonAdaptedMeeting meeting = new JsonAdaptedMeeting(ALICE.getId(), null, VALID_DATE,
+                VALID_DURATION_MINUTE);
         String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT, "Message");
-        assertThrows(IllegalValueException.class, expectedMessage, meeting::toModelType);
+        assertThrows(IllegalValueException.class, expectedMessage, () -> meeting.toModelType(personList));
     }
 
     @Test
     public void toModelType_nullDate_throwsIllegalValueException() {
-        JsonAdaptedMeeting meeting = new JsonAdaptedMeeting(VALID_PERSON, VALID_MESSAGE, null,
-            VALID_DURATION_MINUTE);
+        JsonAdaptedMeeting meeting = new JsonAdaptedMeeting(ALICE.getId(), VALID_MESSAGE, null,
+                VALID_DURATION_MINUTE);
         String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT, "Start Date");
-        assertThrows(IllegalValueException.class, expectedMessage, meeting::toModelType);
+        assertThrows(IllegalValueException.class, expectedMessage, () -> meeting.toModelType(personList));
     }
 
     @Test
     public void toModelType_invalidDate_throwsIllegalValueException() {
         JsonAdaptedMeeting meeting1 =
-            new JsonAdaptedMeeting(VALID_PERSON, VALID_MESSAGE, INVALID_DATE_1, VALID_DURATION_MINUTE);
+                new JsonAdaptedMeeting(ALICE.getId(), VALID_MESSAGE, INVALID_DATE_1, VALID_DURATION_MINUTE);
         JsonAdaptedMeeting meeting2 =
-            new JsonAdaptedMeeting(VALID_PERSON, VALID_MESSAGE, INVALID_DATE_2, VALID_DURATION_MINUTE);
+                new JsonAdaptedMeeting(ALICE.getId(), VALID_MESSAGE, INVALID_DATE_2, VALID_DURATION_MINUTE);
         String expectedMessage = MESSAGE_INVALID_DATETIME;
-        assertThrows(IllegalValueException.class, expectedMessage, meeting1::toModelType);
-        assertThrows(IllegalValueException.class, expectedMessage, meeting2::toModelType);
+        assertThrows(IllegalValueException.class, expectedMessage, () -> meeting1.toModelType(personList));
+        assertThrows(IllegalValueException.class, expectedMessage, () -> meeting2.toModelType(personList));
     }
 
     @Test
     public void toModelType_nullDuration_throwsIllegalValueException() {
-        JsonAdaptedMeeting meeting = new JsonAdaptedMeeting(VALID_PERSON, VALID_MESSAGE, VALID_DATE,
-            null);
+        JsonAdaptedMeeting meeting = new JsonAdaptedMeeting(ALICE.getId(), VALID_MESSAGE, VALID_DATE,
+                null);
         String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT, "Duration");
-        assertThrows(IllegalValueException.class, expectedMessage, meeting::toModelType);
+        assertThrows(IllegalValueException.class, expectedMessage, () -> meeting.toModelType(personList));
     }
 
     @Test
     public void toModelType_invalidDuration_throwsIllegalValueException() {
         JsonAdaptedMeeting meeting1 =
-            new JsonAdaptedMeeting(VALID_PERSON, VALID_MESSAGE, VALID_DATE, INVALID_DURATION);
+                new JsonAdaptedMeeting(ALICE.getId(), VALID_MESSAGE, VALID_DATE, INVALID_DURATION);
         JsonAdaptedMeeting meeting2 =
-            new JsonAdaptedMeeting(VALID_PERSON, VALID_MESSAGE, VALID_DATE, INVALID_DURATION_DECIMAL);
+                new JsonAdaptedMeeting(ALICE.getId(), VALID_MESSAGE, VALID_DATE, INVALID_DURATION_DECIMAL);
         String expectedMessage = DESERIALIZING_DURATION_ERROR_MESSAGE;
-        assertThrows(IllegalValueException.class, expectedMessage, meeting1::toModelType);
-        assertThrows(IllegalValueException.class, expectedMessage, meeting2::toModelType);
+        assertThrows(IllegalValueException.class, expectedMessage, () -> meeting1.toModelType(personList));
+        assertThrows(IllegalValueException.class, expectedMessage, () -> meeting2.toModelType(personList));
     }
 
 }

--- a/src/test/java/seedu/address/storage/JsonAdaptedMeetingTest.java
+++ b/src/test/java/seedu/address/storage/JsonAdaptedMeetingTest.java
@@ -24,7 +24,7 @@ public class JsonAdaptedMeetingTest {
     private static final String INVALID_DURATION = "30 minutes";
     private static final String INVALID_DURATION_DECIMAL = "PT30.5M";
 
-    private static final JsonAdaptedPerson VALID_PERSON = new JsonAdaptedPerson(ALICE);
+    private static final Integer VALID_PERSON_ID = ALICE.getId();
     private static final String VALID_MESSAGE = "Lunch";
     private static final String VALID_DATE = "2020-10-30T15:19";
     private static final String VALID_DURATION_MINUTE = "PT1H40M";
@@ -60,7 +60,7 @@ public class JsonAdaptedMeetingTest {
 
     @Test
     public void toModelType_nullMessage_throwsIllegalValueException() {
-        JsonAdaptedMeeting meeting = new JsonAdaptedMeeting(ALICE.getId(), null, VALID_DATE,
+        JsonAdaptedMeeting meeting = new JsonAdaptedMeeting(VALID_PERSON_ID, null, VALID_DATE,
                 VALID_DURATION_MINUTE);
         String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT, "Message");
         assertThrows(IllegalValueException.class, expectedMessage, () -> meeting.toModelType(personList));
@@ -68,7 +68,7 @@ public class JsonAdaptedMeetingTest {
 
     @Test
     public void toModelType_nullDate_throwsIllegalValueException() {
-        JsonAdaptedMeeting meeting = new JsonAdaptedMeeting(ALICE.getId(), VALID_MESSAGE, null,
+        JsonAdaptedMeeting meeting = new JsonAdaptedMeeting(VALID_PERSON_ID, VALID_MESSAGE, null,
                 VALID_DURATION_MINUTE);
         String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT, "Start Date");
         assertThrows(IllegalValueException.class, expectedMessage, () -> meeting.toModelType(personList));
@@ -77,9 +77,9 @@ public class JsonAdaptedMeetingTest {
     @Test
     public void toModelType_invalidDate_throwsIllegalValueException() {
         JsonAdaptedMeeting meeting1 =
-                new JsonAdaptedMeeting(ALICE.getId(), VALID_MESSAGE, INVALID_DATE_1, VALID_DURATION_MINUTE);
+                new JsonAdaptedMeeting(VALID_PERSON_ID, VALID_MESSAGE, INVALID_DATE_1, VALID_DURATION_MINUTE);
         JsonAdaptedMeeting meeting2 =
-                new JsonAdaptedMeeting(ALICE.getId(), VALID_MESSAGE, INVALID_DATE_2, VALID_DURATION_MINUTE);
+                new JsonAdaptedMeeting(VALID_PERSON_ID, VALID_MESSAGE, INVALID_DATE_2, VALID_DURATION_MINUTE);
         String expectedMessage = MESSAGE_INVALID_DATETIME;
         assertThrows(IllegalValueException.class, expectedMessage, () -> meeting1.toModelType(personList));
         assertThrows(IllegalValueException.class, expectedMessage, () -> meeting2.toModelType(personList));
@@ -87,7 +87,7 @@ public class JsonAdaptedMeetingTest {
 
     @Test
     public void toModelType_nullDuration_throwsIllegalValueException() {
-        JsonAdaptedMeeting meeting = new JsonAdaptedMeeting(ALICE.getId(), VALID_MESSAGE, VALID_DATE,
+        JsonAdaptedMeeting meeting = new JsonAdaptedMeeting(VALID_PERSON_ID, VALID_MESSAGE, VALID_DATE,
                 null);
         String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT, "Duration");
         assertThrows(IllegalValueException.class, expectedMessage, () -> meeting.toModelType(personList));
@@ -96,9 +96,9 @@ public class JsonAdaptedMeetingTest {
     @Test
     public void toModelType_invalidDuration_throwsIllegalValueException() {
         JsonAdaptedMeeting meeting1 =
-                new JsonAdaptedMeeting(ALICE.getId(), VALID_MESSAGE, VALID_DATE, INVALID_DURATION);
+                new JsonAdaptedMeeting(VALID_PERSON_ID, VALID_MESSAGE, VALID_DATE, INVALID_DURATION);
         JsonAdaptedMeeting meeting2 =
-                new JsonAdaptedMeeting(ALICE.getId(), VALID_MESSAGE, VALID_DATE, INVALID_DURATION_DECIMAL);
+                new JsonAdaptedMeeting(VALID_PERSON_ID, VALID_MESSAGE, VALID_DATE, INVALID_DURATION_DECIMAL);
         String expectedMessage = DESERIALIZING_DURATION_ERROR_MESSAGE;
         assertThrows(IllegalValueException.class, expectedMessage, () -> meeting1.toModelType(personList));
         assertThrows(IllegalValueException.class, expectedMessage, () -> meeting2.toModelType(personList));

--- a/src/test/java/seedu/address/storage/JsonAdaptedReminderTest.java
+++ b/src/test/java/seedu/address/storage/JsonAdaptedReminderTest.java
@@ -3,11 +3,16 @@ package seedu.address.storage;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_DATETIME;
+import static seedu.address.storage.JsonAdaptedReminder.INVALID_CONTACT_ID;
 import static seedu.address.storage.JsonAdaptedReminder.MISSING_FIELD_MESSAGE_FORMAT;
 import static seedu.address.testutil.Assert.assertThrows;
 import static seedu.address.testutil.person.TypicalPersons.ALICE;
 import static seedu.address.testutil.reminder.TypicalReminders.CALL_ALICE;
 
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import seedu.address.commons.exceptions.IllegalValueException;
@@ -17,55 +22,69 @@ public class JsonAdaptedReminderTest {
     private static final String INVALID_DATE_1 = "2020/10/10 10AM";
     private static final String INVALID_DATE_2 = "30/10/2020 12:12";
 
-    private static final JsonAdaptedPerson VALID_PERSON = new JsonAdaptedPerson(ALICE);
+    private static final Integer VALID_PERSON_ID = ALICE.getId();
     private static final String VALID_MESSAGE = "Call Alice";
     private static final String VALID_DATE = "2020-10-30T15:19";
+    private List<Person> personList = new ArrayList<>();
+
+    @BeforeEach
+    public void setUp() {
+        personList.add(ALICE);
+    }
 
     @Test
     public void toModelType_validReminderDetails_returnsReminder() throws Exception {
         JsonAdaptedReminder reminder = new JsonAdaptedReminder(CALL_ALICE);
-        assertEquals(CALL_ALICE, reminder.toModelType());
+        assertEquals(CALL_ALICE, reminder.toModelType(personList));
     }
 
     @Test
-    public void toModelType_nullPerson_throwsIllegalValueException() {
+    public void toModelType_nullPersonId_throwsIllegalValueException() {
         JsonAdaptedReminder reminder =
-            new JsonAdaptedReminder(null, VALID_MESSAGE, VALID_DATE, false);
+                new JsonAdaptedReminder(null, VALID_MESSAGE, VALID_DATE, false);
         String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT, Person.class.getSimpleName());
-        assertThrows(IllegalValueException.class, expectedMessage, reminder::toModelType);
+        assertThrows(IllegalValueException.class, expectedMessage, () -> reminder.toModelType(personList));
+    }
+
+    @Test
+    public void toModelType_invalidPersonId_throwsIllegalValueException() {
+        JsonAdaptedReminder reminder =
+                new JsonAdaptedReminder(-134, VALID_MESSAGE, VALID_DATE, false);
+        String expectedMessage = INVALID_CONTACT_ID;
+        assertThrows(IllegalValueException.class, expectedMessage, () -> reminder.toModelType(personList));
     }
 
     @Test
     public void toModelType_nullMessage_throwsIllegalValueException() {
         JsonAdaptedReminder reminder =
-            new JsonAdaptedReminder(VALID_PERSON, null, VALID_DATE, false);
+                new JsonAdaptedReminder(VALID_PERSON_ID, null, VALID_DATE, false);
         String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT, "Message");
-        assertThrows(IllegalValueException.class, expectedMessage, reminder::toModelType);
+        assertThrows(IllegalValueException.class, expectedMessage, () -> reminder.toModelType(personList));
     }
 
     @Test
     public void toModelType_nullDate_throwsIllegalValueException() {
         JsonAdaptedReminder reminder =
-            new JsonAdaptedReminder(VALID_PERSON, VALID_MESSAGE, null, false);
+                new JsonAdaptedReminder(VALID_PERSON_ID, VALID_MESSAGE, null, false);
         String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT, "DateTime");
-        assertThrows(IllegalValueException.class, expectedMessage, reminder::toModelType);
+        assertThrows(IllegalValueException.class, expectedMessage, () -> reminder.toModelType(personList));
     }
 
     @Test
     public void toModelType_nullStatus_defaultsToPending() throws IllegalValueException {
         JsonAdaptedReminder reminder =
-                new JsonAdaptedReminder(VALID_PERSON, VALID_MESSAGE, VALID_DATE, null);
-        assertFalse(reminder.toModelType().isCompleted());
+                new JsonAdaptedReminder(VALID_PERSON_ID, VALID_MESSAGE, VALID_DATE, null);
+        assertFalse(reminder.toModelType(personList).isCompleted());
     }
 
     @Test
     public void toModelType_invalidDate_throwsIllegalValueException() {
         JsonAdaptedReminder reminder1 =
-            new JsonAdaptedReminder(VALID_PERSON, VALID_MESSAGE, INVALID_DATE_1, false);
+                new JsonAdaptedReminder(VALID_PERSON_ID, VALID_MESSAGE, INVALID_DATE_1, false);
         JsonAdaptedReminder reminder2 =
-            new JsonAdaptedReminder(VALID_PERSON, VALID_MESSAGE, INVALID_DATE_2, false);
+                new JsonAdaptedReminder(VALID_PERSON_ID, VALID_MESSAGE, INVALID_DATE_2, false);
         String expectedMessage = MESSAGE_INVALID_DATETIME;
-        assertThrows(IllegalValueException.class, expectedMessage, reminder1::toModelType);
-        assertThrows(IllegalValueException.class, expectedMessage, reminder2::toModelType);
+        assertThrows(IllegalValueException.class, expectedMessage, () -> reminder1.toModelType(personList));
+        assertThrows(IllegalValueException.class, expectedMessage, () -> reminder2.toModelType(personList));
     }
 }


### PR DESCRIPTION
Closes #139

Changes:
- Refactored `JsonAdaptedMeeting` and `JsonAdaptedReminder` to store `personId` rather than `person`
- Added propagation of contact edits to associated meetings and reminders (I think this should be done for sales as well? Not sure)
- Updated and added tests 

![propagation of contact edits](https://user-images.githubusercontent.com/24363622/97142858-775f3f80-179c-11eb-93a9-ddc400785a04.gif)
