### PR TITLE
Remove totalSaleAmount from Person class

### DIFF
--- a/src/main/java/seedu/address/logic/commands/archive/AddCommand.java
+++ b/src/main/java/seedu/address/logic/commands/archive/AddCommand.java
@@ -53,8 +53,7 @@ public class AddCommand extends Command {
                 personToArchive.getAddress(),
                 personToArchive.getTags(),
                 personToArchive.getRemark(),
-                !personToArchive.isArchived(),
-                personToArchive.getTotalSalesAmount()
+                !personToArchive.isArchived()
         );
         model.setPerson(personToArchive, archivedPerson);
         model.updateFilteredPersonList(PREDICATE_SHOW_UNARCHIVED_PERSONS);

--- a/src/main/java/seedu/address/logic/commands/archive/RemoveCommand.java
+++ b/src/main/java/seedu/address/logic/commands/archive/RemoveCommand.java
@@ -55,8 +55,7 @@ public class RemoveCommand extends Command {
                 personToUnarchive.getAddress(),
                 personToUnarchive.getTags(),
                 personToUnarchive.getRemark(),
-                false,
-                personToUnarchive.getTotalSalesAmount()
+                false
         );
         model.setPerson(personToUnarchive, unarchivedPerson);
         model.updateFilteredPersonList(PREDICATE_SHOW_ARCHIVED_PERSONS);

--- a/src/main/java/seedu/address/logic/commands/contact/AddCommand.java
+++ b/src/main/java/seedu/address/logic/commands/contact/AddCommand.java
@@ -9,7 +9,6 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_CONTACT_PHONE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_CONTACT_REMARK;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
 
-import java.math.BigDecimal;
 import java.util.Set;
 
 import seedu.address.commons.core.Messages;

--- a/src/main/java/seedu/address/logic/commands/contact/AddCommand.java
+++ b/src/main/java/seedu/address/logic/commands/contact/AddCommand.java
@@ -76,7 +76,7 @@ public class AddCommand extends Command {
         requireNonNull(model);
         int id = model.getLatestContactId() + 1;
 
-        Person toAdd = new Person(id, name, phone, email, address, tagList, remark, false, BigDecimal.ZERO);
+        Person toAdd = new Person(id, name, phone, email, address, tagList, remark, false);
 
         if (!model.contactTagsExist(toAdd)) {
             throw new CommandException(Messages.MESSAGE_CONTACT_TAGS_NOT_FOUND);

--- a/src/main/java/seedu/address/logic/commands/contact/EditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/contact/EditCommand.java
@@ -116,10 +116,9 @@ public class EditCommand extends Command {
         Address updatedAddress = editPersonDescriptor.getAddress().orElse(personToEdit.getAddress());
         Set<Tag> updatedTags = editPersonDescriptor.getTags().orElse(personToEdit.getTags());
         Remark updatedRemark = editPersonDescriptor.getRemark().orElse(personToEdit.getRemark());
-        BigDecimal updatedTotalSalesAmount = personToEdit.getTotalSalesAmount();
 
         return new Person(id, updatedName, updatedPhone, updatedEmail, updatedAddress,
-                updatedTags, updatedRemark, personToEdit.isArchived(), updatedTotalSalesAmount);
+                updatedTags, updatedRemark, personToEdit.isArchived());
     }
 
     @Override

--- a/src/main/java/seedu/address/logic/commands/contact/EditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/contact/EditCommand.java
@@ -10,7 +10,6 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
 import static seedu.address.model.Model.PREDICATE_SHOW_ARCHIVED_PERSONS;
 import static seedu.address.model.Model.PREDICATE_SHOW_UNARCHIVED_PERSONS;
 
-import java.math.BigDecimal;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;

--- a/src/main/java/seedu/address/logic/commands/contact/SortCommand.java
+++ b/src/main/java/seedu/address/logic/commands/contact/SortCommand.java
@@ -3,7 +3,6 @@ package seedu.address.logic.commands.contact;
 import static java.util.Objects.requireNonNull;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_CONTACT_EMAIL;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_CONTACT_NAME;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_TOTAL_SALES;
 
 import java.util.Comparator;
 

--- a/src/main/java/seedu/address/logic/commands/contact/SortCommand.java
+++ b/src/main/java/seedu/address/logic/commands/contact/SortCommand.java
@@ -64,8 +64,6 @@ public class SortCommand extends Command {
             this.comparator = Comparator.comparing(person -> person.getName().fullName.toLowerCase());
         } else if (sortingAttribute.equals(PREFIX_CONTACT_EMAIL)) {
             this.comparator = Comparator.comparing(person -> person.getEmail().value.toLowerCase());
-        } else if (sortingAttribute.equals(PREFIX_TOTAL_SALES)) {
-            this.comparator = Comparator.comparing(Person::getTotalSalesAmount);
         } else {
             throw new CommandException(MESSAGE_SORTING_ATTRIBUTE_INVALID);
         }

--- a/src/main/java/seedu/address/logic/commands/sale/AddCommand.java
+++ b/src/main/java/seedu/address/logic/commands/sale/AddCommand.java
@@ -102,23 +102,17 @@ public class AddCommand extends Command {
         List<Sale> salesAdded = new ArrayList<>();
 
         for (Index index : indexList) {
-            Person personToEdit = lastShownList.get(index.getZeroBased());
-            Sale toAdd = new Sale(itemName, personToEdit, dateOfPurchase, quantity, unitPrice, tagList);
+            Person buyer = lastShownList.get(index.getZeroBased());
+            Sale toAdd = new Sale(itemName, buyer, dateOfPurchase, quantity, unitPrice, tagList);
 
             if (!model.saleTagsExist(toAdd.getTags())) {
                 throw new CommandException(Messages.MESSAGE_SALE_TAGS_NOT_FOUND);
             }
-            BigDecimal newTotalSalesAmount = toAdd.getTotalCost().add(personToEdit.getTotalSalesAmount());
-
-            Person editedPerson = new Person(personToEdit.getId(), personToEdit.getName(), personToEdit.getPhone(),
-                    personToEdit.getEmail(), personToEdit.getAddress(), personToEdit.getTags(),
-                    personToEdit.getRemark(), personToEdit.isArchived(), newTotalSalesAmount);
 
             if (model.hasSale(toAdd)) {
                 duplicatedSales.add(toAdd);
             } else {
                 model.addSale(toAdd);
-                model.setPerson(personToEdit, editedPerson);
                 salesAdded.add(toAdd);
             }
         }

--- a/src/main/java/seedu/address/logic/commands/sale/AddCommand.java
+++ b/src/main/java/seedu/address/logic/commands/sale/AddCommand.java
@@ -88,7 +88,7 @@ public class AddCommand extends Command {
         requireNonNull(model);
 
         List<Person> lastShownList = model.getSortedPersonList();
-        assert MassSaleCommandUtil.arePersonIndexesValid(lastShownList, indexList);
+        MassSaleCommandUtil.arePersonIndexesValid(lastShownList, indexList);
 
         if (!model.saleTagsExist(tagList)) {
             throw new CommandException(Messages.MESSAGE_SALE_TAGS_NOT_FOUND);

--- a/src/main/java/seedu/address/logic/commands/sale/AddCommand.java
+++ b/src/main/java/seedu/address/logic/commands/sale/AddCommand.java
@@ -9,12 +9,10 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_SALE_QUANTITY;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_SALE_UNIT_PRICE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
 
-import java.math.BigDecimal;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
-import java.util.stream.Collectors;
 
 import seedu.address.commons.core.Messages;
 import seedu.address.commons.core.index.Index;

--- a/src/main/java/seedu/address/logic/commands/sale/AddCommand.java
+++ b/src/main/java/seedu/address/logic/commands/sale/AddCommand.java
@@ -88,14 +88,10 @@ public class AddCommand extends Command {
         requireNonNull(model);
 
         List<Person> lastShownList = model.getSortedPersonList();
+        assert MassSaleCommandUtil.arePersonIndexesValid(lastShownList, indexList);
 
-        List<Index> invalidIndexes = indexList
-                .parallelStream().filter(personIndex -> personIndex.getZeroBased() >= lastShownList.size())
-                .collect(Collectors.toList());
-
-        if (!invalidIndexes.isEmpty()) {
-            throw new CommandException(MassSaleCommandUtil.generateInvalidIndexMessage(
-                    Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEXES, invalidIndexes));
+        if (!model.saleTagsExist(tagList)) {
+            throw new CommandException(Messages.MESSAGE_SALE_TAGS_NOT_FOUND);
         }
 
         List<Sale> duplicatedSales = new ArrayList<>();
@@ -104,10 +100,6 @@ public class AddCommand extends Command {
         for (Index index : indexList) {
             Person buyer = lastShownList.get(index.getZeroBased());
             Sale toAdd = new Sale(itemName, buyer, dateOfPurchase, quantity, unitPrice, tagList);
-
-            if (!model.saleTagsExist(toAdd.getTags())) {
-                throw new CommandException(Messages.MESSAGE_SALE_TAGS_NOT_FOUND);
-            }
 
             if (model.hasSale(toAdd)) {
                 duplicatedSales.add(toAdd);

--- a/src/main/java/seedu/address/logic/commands/sale/DeleteCommand.java
+++ b/src/main/java/seedu/address/logic/commands/sale/DeleteCommand.java
@@ -11,7 +11,6 @@ import seedu.address.logic.commands.Command;
 import seedu.address.logic.commands.CommandResult;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
-import seedu.address.model.person.Person;
 import seedu.address.model.sale.Sale;
 
 /**

--- a/src/main/java/seedu/address/logic/commands/sale/DeleteCommand.java
+++ b/src/main/java/seedu/address/logic/commands/sale/DeleteCommand.java
@@ -3,12 +3,9 @@ package seedu.address.logic.commands.sale;
 import static java.util.Objects.requireNonNull;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_SALE_INDEX;
 
-import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.stream.Collectors;
 
-import seedu.address.commons.core.Messages;
 import seedu.address.commons.core.index.Index;
 import seedu.address.logic.commands.Command;
 import seedu.address.logic.commands.CommandResult;
@@ -49,36 +46,18 @@ public class DeleteCommand extends Command {
         requireNonNull(model);
 
         List<Sale> sales = model.getSortedSaleList();
-        List<Person> people = model.getSortedPersonList();
 
         if (model.getSortedSaleList().size() == 0) {
             throw new CommandException(MESSAGE_NO_SALES_DISPLAYED);
         }
 
-        List<Index> invalidIndexes = saleIndexes
-                .parallelStream().filter(personIndex -> personIndex.getZeroBased() >= sales.size())
-                .collect(Collectors.toList());
-
-        if (!invalidIndexes.isEmpty()) {
-            throw new CommandException(MassSaleCommandUtil.generateInvalidIndexMessage(
-                    Messages.MESSAGE_INVALID_SALE_DISPLAYED_INDEX, invalidIndexes));
-        }
+        assert MassSaleCommandUtil.areSaleIndexesValid(sales, saleIndexes);
 
         List<Sale> deletedSales = new ArrayList<>();
         for (Index saleIndex : saleIndexes) {
             Sale saleToDelete = sales.get(saleIndex.getZeroBased());
-            Person buyer = people.stream()
-                    .filter(person -> person.equals(saleToDelete.getBuyer()))
-                    .findAny()
-                    .orElse(null);
-            assert buyer != null;
-
             deletedSales.add(saleToDelete);
-
-        }
-
-        for (int i = 0; i < deletedSales.size(); i++) {
-            model.removeSale(deletedSales.get(i));
+            model.removeSale(saleToDelete);
         }
 
         return new CommandResult(String.format(generateSuccessMessage(deletedSales)), false, true);

--- a/src/main/java/seedu/address/logic/commands/sale/DeleteCommand.java
+++ b/src/main/java/seedu/address/logic/commands/sale/DeleteCommand.java
@@ -51,14 +51,16 @@ public class DeleteCommand extends Command {
             throw new CommandException(MESSAGE_NO_SALES_DISPLAYED);
         }
 
-        assert MassSaleCommandUtil.areSaleIndexesValid(sales, saleIndexes);
+        MassSaleCommandUtil.areSaleIndexesValid(sales, saleIndexes);
 
         List<Sale> deletedSales = new ArrayList<>();
         for (Index saleIndex : saleIndexes) {
             Sale saleToDelete = sales.get(saleIndex.getZeroBased());
             deletedSales.add(saleToDelete);
-            model.removeSale(saleToDelete);
         }
+
+        // Need to remove sales after selecting all sales to be deleted, otherwise the indexing will be off
+        deletedSales.forEach(model::removeSale);
 
         return new CommandResult(String.format(generateSuccessMessage(deletedSales)), false, true);
     }

--- a/src/main/java/seedu/address/logic/commands/sale/DeleteCommand.java
+++ b/src/main/java/seedu/address/logic/commands/sale/DeleteCommand.java
@@ -65,30 +65,20 @@ public class DeleteCommand extends Command {
         }
 
         List<Sale> deletedSales = new ArrayList<>();
-        List<Person> previousPersons = new ArrayList<>();
-        List<Person> editedPersons = new ArrayList<>();
         for (Index saleIndex : saleIndexes) {
             Sale saleToDelete = sales.get(saleIndex.getZeroBased());
-            Person personToEdit = people.stream()
+            Person buyer = people.stream()
                     .filter(person -> person.equals(saleToDelete.getBuyer()))
                     .findAny()
                     .orElse(null);
-            assert personToEdit != null;
-
-            BigDecimal newTotalSalesAmount = personToEdit.getTotalSalesAmount().subtract(saleToDelete.getTotalCost());
-
-            Person editedPerson = new Person(personToEdit.getId(), personToEdit.getName(), personToEdit.getPhone(),
-                    personToEdit.getEmail(), personToEdit.getAddress(), personToEdit.getTags(),
-                    personToEdit.getRemark(), personToEdit.isArchived(), newTotalSalesAmount);
+            assert buyer != null;
 
             deletedSales.add(saleToDelete);
-            previousPersons.add(personToEdit);
-            editedPersons.add(editedPerson);
+
         }
 
         for (int i = 0; i < deletedSales.size(); i++) {
             model.removeSale(deletedSales.get(i));
-            model.setPerson(previousPersons.get(i), editedPersons.get(i));
         }
 
         return new CommandResult(String.format(generateSuccessMessage(deletedSales)), false, true);

--- a/src/main/java/seedu/address/logic/commands/sale/EditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/sale/EditCommand.java
@@ -80,16 +80,7 @@ public class EditCommand extends Command {
     public CommandResult execute(Model model) throws CommandException {
         requireNonNull(model);
         List<Sale> lastShownList = model.getSortedSaleList();
-
-        List<Index> invalidIndexes = saleIndexes
-                .parallelStream().filter(personIndex -> personIndex.getZeroBased() >= lastShownList.size())
-                .collect(Collectors.toList());
-
-        // Check if indexes are provided
-        if (!invalidIndexes.isEmpty()) {
-            throw new CommandException(MassSaleCommandUtil.generateInvalidIndexMessage(
-                    Messages.MESSAGE_INVALID_SALE_DISPLAYED_INDEX, invalidIndexes));
-        }
+        assert MassSaleCommandUtil.areSaleIndexesValid(lastShownList, saleIndexes);
 
         // Check if new tags are valid
         if (editSaleDescriptor.getTags().isPresent()) {

--- a/src/main/java/seedu/address/logic/commands/sale/EditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/sale/EditCommand.java
@@ -103,11 +103,6 @@ public class EditCommand extends Command {
 
         for (Index saleIndex : saleIndexes) {
             Sale saleToEdit = lastShownList.get(saleIndex.getZeroBased());
-            Sale editedSale = createEditedSale(saleToEdit, editSaleDescriptor);
-            BigDecimal previousCost = saleToEdit.getTotalCost();
-            BigDecimal newCost = editedSale.getTotalCost();
-            Person initialBuyer = saleToEdit.getBuyer();
-            Person newBuyer = initialBuyer;
 
             if (personIndex != null) {
                 List<Person> lastShownPeople = model.getSortedPersonList();
@@ -115,35 +110,16 @@ public class EditCommand extends Command {
                     throw new CommandException(Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
                 }
 
-                initialBuyer = Person.changeSaleAmount(initialBuyer,
-                        initialBuyer.getTotalSalesAmount().subtract(previousCost));
-
-                newBuyer = lastShownPeople.get(personIndex.getZeroBased());
-
-                editSaleDescriptor.setBuyer(
-                        Person.changeSaleAmount(newBuyer, newBuyer.getTotalSalesAmount().add(newCost)));
-            } else {
-                BigDecimal changeToSalesAmount = newCost.subtract(previousCost);
-
-                newBuyer = Person.changeSaleAmount(initialBuyer,
-                        initialBuyer.getTotalSalesAmount().subtract(changeToSalesAmount));
-
+                Person newBuyer = lastShownPeople.get(personIndex.getZeroBased());
                 editSaleDescriptor.setBuyer(newBuyer);
             }
 
             // Re-edit sale with new buyer
-            editedSale = createEditedSale(saleToEdit, editSaleDescriptor);
+            Sale editedSale = createEditedSale(saleToEdit, editSaleDescriptor);
 
             if (!saleToEdit.isSameSale(editedSale) && model.hasSale(editedSale)) {
                 invalidSales.add(editedSale);
             } else {
-                if (initialBuyer.isSamePerson(newBuyer)) {
-                    model.setPerson(initialBuyer, newBuyer);
-                } else {
-                    model.setPerson(saleToEdit.getBuyer(), initialBuyer);
-                    model.setPerson(newBuyer, editedSale.getBuyer());
-                }
-
                 model.setSale(saleToEdit, editedSale);
                 editedSales.add(editedSale);
             }

--- a/src/main/java/seedu/address/logic/commands/sale/EditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/sale/EditCommand.java
@@ -10,7 +10,6 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_SALE_QUANTITY;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_SALE_UNIT_PRICE;
 import static seedu.address.model.Model.PREDICATE_SHOW_ALL_SALES;
 
-import java.math.BigDecimal;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -20,7 +19,6 @@ import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
-import java.util.stream.Collectors;
 
 import seedu.address.commons.core.Messages;
 import seedu.address.commons.core.index.Index;
@@ -83,17 +81,17 @@ public class EditCommand extends Command {
         List<Sale> lastShownList = model.getSortedSaleList();
         MassSaleCommandUtil.areSaleIndexesValid(lastShownList, saleIndexes);
 
-        // Check if new tags are valid
+        // Check if new tags are valid.
         if (editSaleDescriptor.getTags().isPresent()) {
             if (!model.saleTagsExist(editSaleDescriptor.getTags().get())) {
                 throw new CommandException(Messages.MESSAGE_SALE_TAGS_NOT_FOUND);
             }
         }
 
-        // Check if new buyer is valid, and add to editSaleDescriptor if it is
+        // Check if new buyer is valid, and add to editSaleDescriptor if it is.
         if (personIndex != null) {
             List<Person> lastShownPeople = model.getSortedPersonList();
-            assert MassSaleCommandUtil.arePersonIndexesValid(lastShownPeople, new ArrayList<>(Arrays.asList(personIndex)));
+            MassSaleCommandUtil.arePersonIndexesValid(lastShownPeople, new ArrayList<>(Arrays.asList(personIndex)));
             Person newBuyer = lastShownPeople.get(personIndex.getZeroBased());
             editSaleDescriptor.setBuyer(newBuyer);
         }
@@ -114,14 +112,13 @@ public class EditCommand extends Command {
         }
 
         model.updateFilteredSaleList(PREDICATE_SHOW_ALL_SALES);
-
         String result = generateResultString(editedSales, invalidSales);
 
         return new CommandResult(result, false, true);
     }
 
     private String generateResultString(List<Sale> editedSales, List<Sale> invalidSales) {
-        String result = "";
+        String result;
 
         if (editedSales.size() > 0) {
             result = MESSAGE_EDIT_SALE_SUCCESS + MassSaleCommandUtil.listAllSales(editedSales);

--- a/src/main/java/seedu/address/logic/commands/sale/MassSaleCommandUtil.java
+++ b/src/main/java/seedu/address/logic/commands/sale/MassSaleCommandUtil.java
@@ -1,11 +1,54 @@
 package seedu.address.logic.commands.sale;
 
 import java.util.List;
+import java.util.stream.Collectors;
 
+import seedu.address.commons.core.Messages;
 import seedu.address.commons.core.index.Index;
+import seedu.address.logic.commands.exceptions.CommandException;
+import seedu.address.model.person.Person;
 import seedu.address.model.sale.Sale;
 
 public class MassSaleCommandUtil {
+
+    /**
+     * Checks if person indexes provided are valid.
+     * @param persons The list of persons in StonksBook.
+     * @param indexList The list of indexes provided to the Sale command.
+     * @return True if all person indexes provided are valid, and throws a CommandException otherwise.
+     * @throws CommandException If any person indexes provided are not valid.
+     */
+    public static boolean arePersonIndexesValid(List<Person> persons, List<Index> indexList) throws CommandException {
+        List<Index> invalidIndexes = indexList
+                .parallelStream().filter(personIndex -> personIndex.getZeroBased() >= persons.size())
+                .collect(Collectors.toList());
+
+        if (!invalidIndexes.isEmpty()) {
+            throw new CommandException(MassSaleCommandUtil.generateInvalidIndexMessage(
+                    Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEXES, invalidIndexes));
+        }
+        return true;
+    }
+
+    /**
+     * Checks if sale indexes provided are valid.
+     * @param sales The list of sales in StonksBook.
+     * @param indexList The list of indexes provided to the Sale command.
+     * @return True if all sale indexes provided are valid, and throws a CommandException otherwise.
+     * @throws CommandException If any sale indexes provided are not valid.
+     */
+    public static boolean areSaleIndexesValid(List<Sale> sales, List<Index> indexList) throws CommandException {
+        List<Index> invalidIndexes = indexList
+                .parallelStream().filter(personIndex -> personIndex.getZeroBased() >= sales.size())
+                .collect(Collectors.toList());
+
+        if (!invalidIndexes.isEmpty()) {
+            throw new CommandException(MassSaleCommandUtil.generateInvalidIndexMessage(
+                    Messages.MESSAGE_INVALID_SALE_DISPLAYED_INDEX, invalidIndexes));
+        }
+        return true;
+    }
+
     /**
      * Generates a message indicating which indexes were invalid.
      * @param message The message preceding the list of invalid indexes.

--- a/src/main/java/seedu/address/logic/parser/CliSyntax.java
+++ b/src/main/java/seedu/address/logic/parser/CliSyntax.java
@@ -12,7 +12,6 @@ public class CliSyntax {
     public static final Prefix PREFIX_CONTACT_ADDRESS = new Prefix("a/");
     public static final Prefix PREFIX_TAG = new Prefix("t/");
     public static final Prefix PREFIX_CONTACT_REMARK = new Prefix("r/");
-    public static final Prefix PREFIX_TOTAL_SALES = new Prefix("s/");
     public static final Prefix PREFIX_DESC_ORDER = new Prefix("desc");
 
     /* Prefix definitions for sales */

--- a/src/main/java/seedu/address/logic/parser/contact/SortCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/contact/SortCommandParser.java
@@ -4,7 +4,6 @@ import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT
 import static seedu.address.logic.parser.CliSyntax.PREFIX_CONTACT_EMAIL;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_CONTACT_NAME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_DESC_ORDER;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_TOTAL_SALES;
 
 import seedu.address.logic.commands.contact.SortCommand;
 import seedu.address.logic.parser.ArgumentMultimap;
@@ -26,8 +25,7 @@ public class SortCommandParser implements Parser<SortCommand> {
      */
     public SortCommand parse(String args) throws ParseException {
         ArgumentMultimap argMultimap =
-            ArgumentTokenizer.tokenize(args, PREFIX_CONTACT_NAME, PREFIX_CONTACT_EMAIL, PREFIX_TOTAL_SALES,
-                    PREFIX_DESC_ORDER);
+            ArgumentTokenizer.tokenize(args, PREFIX_CONTACT_NAME, PREFIX_CONTACT_EMAIL, PREFIX_DESC_ORDER);
 
         Prefix sortingAttribute = null;
 
@@ -39,10 +37,6 @@ public class SortCommandParser implements Parser<SortCommand> {
         }
         if (argMultimap.getValue(PREFIX_CONTACT_EMAIL).isPresent()) {
             sortingAttribute = PREFIX_CONTACT_EMAIL;
-            presentSortingAttributeCounter++;
-        }
-        if (argMultimap.getValue(PREFIX_TOTAL_SALES).isPresent()) {
-            sortingAttribute = PREFIX_TOTAL_SALES;
             presentSortingAttributeCounter++;
         }
 

--- a/src/main/java/seedu/address/model/person/Person.java
+++ b/src/main/java/seedu/address/model/person/Person.java
@@ -28,7 +28,6 @@ public class Person {
     private final Set<Tag> tags = new HashSet<>();
     private final Remark remark;
     private final boolean archived;
-    private final BigDecimal totalSalesAmount;
 
     /**
      * Creates a person object with specified details.
@@ -41,7 +40,7 @@ public class Person {
      * @param remark Remark associated with the person.
      */
     public Person(Integer id, Name name, Phone phone, Email email, Address address,
-                  Set<Tag> tags, Remark remark, boolean archived, BigDecimal totalSalesAmount) {
+                  Set<Tag> tags, Remark remark, boolean archived) {
         requireAllNonNull(name, phone, email, address, tags, remark);
         this.id = id;
         this.name = name;
@@ -51,7 +50,6 @@ public class Person {
         this.tags.addAll(tags);
         this.remark = remark;
         this.archived = archived;
-        this.totalSalesAmount = totalSalesAmount;
     }
 
     public Integer getId() {
@@ -86,16 +84,8 @@ public class Person {
         return remark;
     }
 
-    public BigDecimal getTotalSalesAmount() {
-        return totalSalesAmount;
-    }
-
     public boolean isArchived() {
         return archived;
-    }
-
-    public String getTotalSalesAmountString() {
-        return NumberFormat.getCurrencyInstance().format(totalSalesAmount);
     }
 
     /**
@@ -120,19 +110,6 @@ public class Person {
     }
 
     /**
-     * Creates and returns a new Person with the new specified {@code newSaleAmount}.
-     * @param personToEdit    Person to be edited.
-     * @param newSaleAmount   The new sale amount.
-     * @return A new Person with the new specified {@code newSaleAmount}.
-     */
-    public static Person changeSaleAmount(Person personToEdit, BigDecimal newSaleAmount) {
-        Person editedPerson = new Person(personToEdit.getId(), personToEdit.getName(), personToEdit.getPhone(),
-                personToEdit.getEmail(), personToEdit.getAddress(), personToEdit.getTags(),
-                personToEdit.getRemark(), personToEdit.isArchived(), newSaleAmount);
-        return editedPerson;
-    }
-
-    /**
      * Returns true if both persons have the same identity and data fields.
      * This defines a stronger notion of equality between two persons.
      */
@@ -153,7 +130,7 @@ public class Person {
     @Override
     public int hashCode() {
         // use this method for custom fields hashing instead of implementing your own
-        return Objects.hash(name, phone, email, address, tags, remark, totalSalesAmount);
+        return Objects.hash(name, phone, email, address, tags, remark);
     }
 
     @Override

--- a/src/main/java/seedu/address/model/person/Person.java
+++ b/src/main/java/seedu/address/model/person/Person.java
@@ -2,8 +2,6 @@ package seedu.address.model.person;
 
 import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
 
-import java.math.BigDecimal;
-import java.text.NumberFormat;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.Objects;

--- a/src/main/java/seedu/address/model/person/UniquePersonList.java
+++ b/src/main/java/seedu/address/model/person/UniquePersonList.java
@@ -102,8 +102,7 @@ public class UniquePersonList implements Iterable<Person> {
                         original.getAddress(),
                         tags,
                         original.getRemark(),
-                        original.isArchived(),
-                        original.getTotalSalesAmount());
+                        original.isArchived());
                 internalList.set(i, p);
             }
         }
@@ -127,8 +126,7 @@ public class UniquePersonList implements Iterable<Person> {
                         original.getAddress(),
                         tags,
                         original.getRemark(),
-                        original.isArchived(),
-                        original.getTotalSalesAmount());
+                        original.isArchived());
                 internalList.set(i, p);
             }
         }

--- a/src/main/java/seedu/address/model/util/SampleDataUtil.java
+++ b/src/main/java/seedu/address/model/util/SampleDataUtil.java
@@ -37,25 +37,24 @@ public class SampleDataUtil {
      */
     private static final Person ALEX_YEOH = new Person(1, new Name("Alex Yeoh"), new Phone("87438807"),
             new Email("alexyeoh@example.com"), new Address("Blk 30 Geylang Street 29, #06-40"),
-            getTagSet("friends"), new Remark("Not available on Fridays"), false,
-            new BigDecimal("3382.5"));
+            getTagSet("friends"), new Remark("Not available on Fridays"), false);
     private static final Person BERNICE_YU = new Person(2, new Name("Bernice Yu"),
             new Phone("99272758"), new Email("berniceyu@example.com"),
             new Address("Blk 30 Lorong 3 Serangoon Gardens, #07-18"), getTagSet("colleagues", "friends"),
-            new Remark("Owns a small stationery business"), false, new BigDecimal("1788"));
+            new Remark("Owns a small stationery business"), false);
     private static final Person CHARLOTTE_OLIVEIRO = new Person(3, new Name("Charlotte Oliveiro"),
             new Phone("93210283"), new Email("charlotte@example.com"),
             new Address("Blk 11 Ang Mo Kio Street 74, #11-04"), getTagSet("neighbours"),
-            new Remark(""), false, new BigDecimal("960"));
+            new Remark(""), false);
     private static final Person DAVID_LI = new Person(4, new Name("David Li"), new Phone("91031282"),
             new Email("lidavid@example.com"), new Address("Blk 436 Serangoon Gardens Street 26, #16-43"),
-            getTagSet("family"), new Remark(""), false, BigDecimal.ZERO);
+            getTagSet("family"), new Remark(""), false);
     private static final Person IRFAN_IBRAHIM = new Person(5, new Name("Irfan Ibrahim"), new Phone("92492021"),
             new Email("irfan@example.com"), new Address("Blk 47 Tampines Street 20, #17-35"),
-            getTagSet("classmates"), new Remark("Interested in paper-based products"), false, BigDecimal.ZERO);
+            getTagSet("classmates"), new Remark("Interested in paper-based products"), false);
     private static final Person ROY_BALAKRISHNAN = new Person(6, new Name("Roy Balakrishnan"), new Phone("92624417"),
             new Email("royb@example.com"), new Address("Blk 45 Aljunied Street 85, #11-31"),
-            getTagSet("colleagues"), new Remark(""), false, BigDecimal.ZERO);
+            getTagSet("colleagues"), new Remark(""), false);
 
     /**
      * Sales

--- a/src/main/java/seedu/address/storage/JsonAdaptedPerson.java
+++ b/src/main/java/seedu/address/storage/JsonAdaptedPerson.java
@@ -1,6 +1,5 @@
 package seedu.address.storage;
 
-import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;

--- a/src/main/java/seedu/address/storage/JsonAdaptedPerson.java
+++ b/src/main/java/seedu/address/storage/JsonAdaptedPerson.java
@@ -36,7 +36,6 @@ class JsonAdaptedPerson {
     private final List<JsonAdaptedTag> tagged = new ArrayList<>();
     private final String remark;
     private final boolean archived;
-    private final String totalSalesAmount;
 
     /**
      * Constructs a {@code JsonAdaptedPerson} with the given person details.
@@ -45,8 +44,7 @@ class JsonAdaptedPerson {
     public JsonAdaptedPerson(@JsonProperty("id") Integer id, @JsonProperty("name") String name,
             @JsonProperty("phone") String phone, @JsonProperty("email") String email,
             @JsonProperty("address") String address, @JsonProperty("tagged") List<JsonAdaptedTag> tagged,
-            @JsonProperty("remark") String remark, @JsonProperty("archived") boolean archived,
-            @JsonProperty("totalSalesAmount") String totalSalesAmount) {
+            @JsonProperty("remark") String remark, @JsonProperty("archived") boolean archived) {
         this.id = id;
         this.name = name;
         this.phone = phone;
@@ -57,7 +55,6 @@ class JsonAdaptedPerson {
         }
         this.remark = remark;
         this.archived = archived;
-        this.totalSalesAmount = totalSalesAmount;
     }
 
     /**
@@ -74,7 +71,6 @@ class JsonAdaptedPerson {
                 .collect(Collectors.toList()));
         remark = source.getRemark().value;
         archived = source.isArchived();
-        totalSalesAmount = source.getTotalSalesAmount().setScale(2).toPlainString();
     }
 
     /**
@@ -130,28 +126,8 @@ class JsonAdaptedPerson {
         }
         final Remark modelRemark = new Remark(remark);
 
-        if (totalSalesAmount == null) {
-            throw new IllegalValueException(String.format(MISSING_FIELD_MESSAGE_FORMAT, "Total Sales Amount"));
-        }
-        try {
-            BigDecimal test = new BigDecimal(totalSalesAmount);
-
-            String string = test.stripTrailingZeros().toPlainString();
-            int index = string.indexOf(".");
-            int noOfDecimalPlaces = index < 0 ? 0 : string.length() - index - 1;
-
-            if (noOfDecimalPlaces < 3 && !(test.compareTo(BigDecimal.ZERO) >= 0)) {
-                throw new NumberFormatException();
-            }
-        } catch (NumberFormatException e) {
-            throw new IllegalValueException("Total Sales Amount should be a positive decimal number, "
-                    + "with at most 2 decimal places.");
-        }
-
-        final BigDecimal modelTotalSalesAmount = new BigDecimal(totalSalesAmount);
-
         return new Person(id, modelName, modelPhone, modelEmail, modelAddress,
-                modelTags, modelRemark, archived, modelTotalSalesAmount);
+                modelTags, modelRemark, archived);
     }
 
 }

--- a/src/main/java/seedu/address/ui/PersonCard.java
+++ b/src/main/java/seedu/address/ui/PersonCard.java
@@ -42,8 +42,7 @@ public class PersonCard extends UiPart<Region> {
     private FlowPane tags;
     @FXML
     private Label remark;
-    @FXML
-    private Label totalSalesAmount;
+
     /**
      * Creates a {@code PersonCode} with the given {@code Person} and index to display.
      */
@@ -64,7 +63,6 @@ public class PersonCard extends UiPart<Region> {
             remark.setVisible(false);
             remark.setManaged(false);
         }
-        totalSalesAmount.setText(String.valueOf(person.getTotalSalesAmountString()));
     }
 
     @Override

--- a/src/main/resources/view/PersonListCard.fxml
+++ b/src/main/resources/view/PersonListCard.fxml
@@ -32,7 +32,6 @@
       <Label fx:id="address" styleClass="cell_small_label" text="\$address" />
       <Label fx:id="email" styleClass="cell_small_label" text="\$email" />
       <Label fx:id="remark" styleClass="cell_small_label" wrapText="true" text="\$remark" />
-      <Label fx:id="totalSalesAmount" styleClass="cell_small_label" wrapText="true" text="\$totalSalesAmount" />
     </VBox>
   </GridPane>
 </HBox>

--- a/src/test/java/seedu/address/logic/commands/archive/AddCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/archive/AddCommandTest.java
@@ -41,8 +41,7 @@ public class AddCommandTest {
                 personToArchive.getAddress(),
                 personToArchive.getTags(),
                 personToArchive.getRemark(),
-                !personToArchive.isArchived(),
-                personToArchive.getTotalSalesAmount()
+                !personToArchive.isArchived()
         );
         expectedModel.setPerson(personToArchive, archivedPerson);
 

--- a/src/test/java/seedu/address/logic/commands/archive/RemoveCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/archive/RemoveCommandTest.java
@@ -48,8 +48,7 @@ public class RemoveCommandTest {
                 personToRemove.getAddress(),
                 personToRemove.getTags(),
                 personToRemove.getRemark(),
-                !personToRemove.isArchived(),
-                personToRemove.getTotalSalesAmount()
+                !personToRemove.isArchived()
         );
         expectedModel.setPerson(personToRemove, removedPerson);
         expectedModel.updateFilteredPersonList(Model.PREDICATE_SHOW_ARCHIVED_PERSONS);

--- a/src/test/java/seedu/address/logic/commands/contact/EditCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/contact/EditCommandTest.java
@@ -40,8 +40,7 @@ public class EditCommandTest {
 
     @Test
     public void execute_allFieldsSpecifiedUnfilteredList_success() {
-        Person editedPerson = new PersonBuilder().withName("Allison Pauline")
-                .withTotalSalesAmount(new BigDecimal("0.8")).build();
+        Person editedPerson = new PersonBuilder().withName("Allison Pauline").build();
         EditPersonDescriptor descriptor = new EditPersonDescriptorBuilder(editedPerson)
                 .withName("Allison Pauline").build();
         EditCommand editCommand = new EditCommand(INDEX_FIRST_ITEM, descriptor);

--- a/src/test/java/seedu/address/logic/commands/contact/EditCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/contact/EditCommandTest.java
@@ -14,8 +14,6 @@ import static seedu.address.testutil.TypicalAddressBook.getTypicalAddressBookInR
 import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_ITEM;
 import static seedu.address.testutil.TypicalIndexes.INDEX_SECOND_ITEM;
 
-import java.math.BigDecimal;
-
 import org.junit.jupiter.api.Test;
 
 import seedu.address.commons.core.Messages;

--- a/src/test/java/seedu/address/logic/commands/contact/SortCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/contact/SortCommandTest.java
@@ -8,11 +8,8 @@ import static seedu.address.logic.commands.contact.SortCommand.MESSAGE_SORTING_A
 import static seedu.address.logic.parser.CliSyntax.PREFIX_CONTACT_ADDRESS;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_CONTACT_EMAIL;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_CONTACT_NAME;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_TOTAL_SALES;
 import static seedu.address.testutil.TypicalAddressBook.getTypicalAddressBookInReverse;
 import static seedu.address.testutil.person.TypicalPersons.getTypicalAddressBook;
-
-import java.util.Comparator;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -25,7 +22,6 @@ import seedu.address.model.AddressBook;
 import seedu.address.model.Model;
 import seedu.address.model.ModelManager;
 import seedu.address.model.UserPrefs;
-import seedu.address.model.person.Person;
 
 /**
  * Contains integration tests (interaction with the Model) and unit tests for SortCommand.
@@ -150,62 +146,6 @@ public class SortCommandTest {
         Model expectedReverseModel = new ModelManager(new AddressBook(reversedModel.getAddressBook()), new UserPrefs());
         expectedReverseModel.updateSortedPersonList((x, y) -> y.getEmail().value
                 .compareToIgnoreCase(x.getEmail().value));
-
-        commandResult = sortCommand.execute(reversedModel);
-
-        assertEquals(new CommandResult(expectedMessage), commandResult);
-        assertEquals(expectedReverseModel, reversedModel);
-
-    }
-
-    @Test
-    public void execute_totalSalesOnly_success() throws CommandException {
-        Prefix prefix = PREFIX_TOTAL_SALES;
-        boolean isDesc = false;
-
-        SortCommand sortCommand = new SortCommand(prefix, isDesc);
-
-        String expectedMessage = SortCommand.MESSAGE_SUCCESS;
-
-        Model expectedModel = new ModelManager(new AddressBook(model.getAddressBook()), new UserPrefs());
-        Comparator<Person> comparator = Comparator.comparing(x -> x.getTotalSalesAmount());
-        expectedModel.updateSortedPersonList(comparator);
-
-        CommandResult commandResult = sortCommand.execute(model);
-
-        assertEquals(new CommandResult(expectedMessage), commandResult);
-        assertEquals(expectedModel, model);
-
-        Model expectedReverseModel = new ModelManager(new AddressBook(reversedModel.getAddressBook()), new UserPrefs());
-        expectedReverseModel.updateSortedPersonList(comparator);
-
-        commandResult = sortCommand.execute(reversedModel);
-
-        assertEquals(new CommandResult(expectedMessage), commandResult);
-        assertEquals(expectedReverseModel, reversedModel);
-
-    }
-
-    @Test
-    public void execute_totalSalesAndDesc_success() throws CommandException {
-        Prefix prefix = PREFIX_TOTAL_SALES;
-        boolean isDesc = true;
-
-        SortCommand sortCommand = new SortCommand(prefix, isDesc);
-
-        String expectedMessage = SortCommand.MESSAGE_SUCCESS;
-
-        Model expectedModel = new ModelManager(new AddressBook(model.getAddressBook()), new UserPrefs());
-        Comparator<Person> comparator = Comparator.comparing(x -> x.getTotalSalesAmount());
-        expectedModel.updateSortedPersonList(comparator.reversed());
-
-        CommandResult commandResult = sortCommand.execute(model);
-
-        assertEquals(new CommandResult(expectedMessage), commandResult);
-        assertEquals(expectedModel, model);
-
-        Model expectedReverseModel = new ModelManager(new AddressBook(reversedModel.getAddressBook()), new UserPrefs());
-        expectedReverseModel.updateSortedPersonList(comparator.reversed());
 
         commandResult = sortCommand.execute(reversedModel);
 

--- a/src/test/java/seedu/address/logic/commands/sale/DeleteCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/sale/DeleteCommandTest.java
@@ -65,8 +65,7 @@ public class DeleteCommandTest {
 
         assertNotNull(toEdit);
 
-        Person newPerson = new PersonBuilder(toEdit)
-                .withTotalSalesAmount(toEdit.getTotalSalesAmount().subtract(saleToDelete.getTotalCost())).build();
+        Person newPerson = new PersonBuilder(toEdit).build();
 
         expectedModel.setPerson(toEdit, newPerson);
         expectedModel.removeSale(saleToDelete);

--- a/src/test/java/seedu/address/logic/parser/contact/SortCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/contact/SortCommandParserTest.java
@@ -6,7 +6,6 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_CONTACT_EMAIL;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_CONTACT_NAME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_DESC_ORDER;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_SALE_QUANTITY;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_TOTAL_SALES;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
 
@@ -47,20 +46,6 @@ public class SortCommandParserTest {
     }
 
     @Test
-    public void parse_totalSalesOnly_success() {
-        String args = " " + PREFIX_TOTAL_SALES.getPrefix();
-        SortCommand expectedSortCommand = new SortCommand(PREFIX_TOTAL_SALES, false);
-        assertParseSuccess(sortCommandParser, args, expectedSortCommand);
-    }
-
-    @Test
-    public void parse_totalSalesAndDesc_success() {
-        String args = " " + PREFIX_TOTAL_SALES.getPrefix() + " " + PREFIX_DESC_ORDER;
-        SortCommand expectedSortCommand = new SortCommand(PREFIX_TOTAL_SALES, true);
-        assertParseSuccess(sortCommandParser, args, expectedSortCommand);
-    }
-
-    @Test
     public void parse_noInputs_failure() {
         String args = " ";
         assertParseFailure(sortCommandParser, args,
@@ -92,21 +77,6 @@ public class SortCommandParserTest {
     public void parse_moreThanOneAttribute_failure() {
         // email and name
         String args = " " + PREFIX_CONTACT_EMAIL + " " + PREFIX_CONTACT_NAME;
-        assertParseFailure(sortCommandParser, args,
-                String.format(MESSAGE_INVALID_COMMAND_FORMAT, SortCommand.MESSAGE_USAGE));
-
-        // email and total sales
-        args = " " + PREFIX_CONTACT_EMAIL + " " + PREFIX_TOTAL_SALES;
-        assertParseFailure(sortCommandParser, args,
-                String.format(MESSAGE_INVALID_COMMAND_FORMAT, SortCommand.MESSAGE_USAGE));
-
-        // name and total sales
-        args = " " + PREFIX_CONTACT_NAME + " " + PREFIX_TOTAL_SALES;
-        assertParseFailure(sortCommandParser, args,
-                String.format(MESSAGE_INVALID_COMMAND_FORMAT, SortCommand.MESSAGE_USAGE));
-
-        // name and email and total sales
-        args = " " + PREFIX_CONTACT_NAME + " " + PREFIX_CONTACT_EMAIL + " " + PREFIX_TOTAL_SALES;
         assertParseFailure(sortCommandParser, args,
                 String.format(MESSAGE_INVALID_COMMAND_FORMAT, SortCommand.MESSAGE_USAGE));
     }

--- a/src/test/java/seedu/address/storage/JsonAdaptedPersonTest.java
+++ b/src/test/java/seedu/address/storage/JsonAdaptedPersonTest.java
@@ -38,9 +38,6 @@ public class JsonAdaptedPersonTest {
             .map(JsonAdaptedTag::new)
             .collect(Collectors.toList());
     private static final String VALID_REMARK = BENSON.getRemark().toString();
-    private static final String VALID_TOTAL_SALES_AMOUNT = BENSON.getTotalSalesAmountString();
-    private static final String ZERO_TOTAL_SALES_AMOUNT_1 = "0";
-    private static final String ZERO_TOTAL_SALES_AMOUNT_2 = "0.00";
 
     @Test
     public void toModelType_validPersonDetails_returnsPerson() throws Exception {
@@ -51,7 +48,7 @@ public class JsonAdaptedPersonTest {
     @Test
     public void toModelType_invalidName_throwsIllegalValueException() {
         JsonAdaptedPerson person = new JsonAdaptedPerson(VALID_ID, INVALID_NAME, VALID_PHONE, VALID_EMAIL,
-                VALID_ADDRESS, VALID_TAGS, VALID_REMARK, false, VALID_TOTAL_SALES_AMOUNT);
+                VALID_ADDRESS, VALID_TAGS, VALID_REMARK, false);
         String expectedMessage = Name.MESSAGE_CONSTRAINTS;
         assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
@@ -59,7 +56,7 @@ public class JsonAdaptedPersonTest {
     @Test
     public void toModelType_nullName_throwsIllegalValueException() {
         JsonAdaptedPerson person = new JsonAdaptedPerson(VALID_ID, null, VALID_PHONE, VALID_EMAIL, VALID_ADDRESS,
-                VALID_TAGS, VALID_REMARK, false, VALID_TOTAL_SALES_AMOUNT);
+                VALID_TAGS, VALID_REMARK, false);
         String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT, Name.class.getSimpleName());
         assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
@@ -67,7 +64,7 @@ public class JsonAdaptedPersonTest {
     @Test
     public void toModelType_invalidPhone_throwsIllegalValueException() {
         JsonAdaptedPerson person = new JsonAdaptedPerson(VALID_ID, VALID_NAME, INVALID_PHONE, VALID_EMAIL,
-                VALID_ADDRESS, VALID_TAGS, VALID_REMARK, false, VALID_TOTAL_SALES_AMOUNT);
+                VALID_ADDRESS, VALID_TAGS, VALID_REMARK, false);
         String expectedMessage = Phone.MESSAGE_CONSTRAINTS;
         assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
@@ -75,7 +72,7 @@ public class JsonAdaptedPersonTest {
     @Test
     public void toModelType_nullPhone_throwsIllegalValueException() {
         JsonAdaptedPerson person = new JsonAdaptedPerson(VALID_ID, VALID_NAME, null, VALID_EMAIL, VALID_ADDRESS,
-                VALID_TAGS, VALID_REMARK, false, VALID_TOTAL_SALES_AMOUNT);
+                VALID_TAGS, VALID_REMARK, false);
         String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT, Phone.class.getSimpleName());
         assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
@@ -83,7 +80,7 @@ public class JsonAdaptedPersonTest {
     @Test
     public void toModelType_invalidEmail_throwsIllegalValueException() {
         JsonAdaptedPerson person = new JsonAdaptedPerson(VALID_ID, VALID_NAME, VALID_PHONE, INVALID_EMAIL,
-                VALID_ADDRESS, VALID_TAGS, VALID_REMARK, false, VALID_TOTAL_SALES_AMOUNT);
+                VALID_ADDRESS, VALID_TAGS, VALID_REMARK, false);
         String expectedMessage = Email.MESSAGE_CONSTRAINTS;
         assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
@@ -91,7 +88,7 @@ public class JsonAdaptedPersonTest {
     @Test
     public void toModelType_nullEmail_throwsIllegalValueException() {
         JsonAdaptedPerson person = new JsonAdaptedPerson(VALID_ID, VALID_NAME, VALID_PHONE, null, VALID_ADDRESS,
-                VALID_TAGS, VALID_REMARK, false, VALID_TOTAL_SALES_AMOUNT);
+                VALID_TAGS, VALID_REMARK, false);
         String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT, Email.class.getSimpleName());
         assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
@@ -99,7 +96,7 @@ public class JsonAdaptedPersonTest {
     @Test
     public void toModelType_invalidAddress_throwsIllegalValueException() {
         JsonAdaptedPerson person = new JsonAdaptedPerson(VALID_ID, VALID_NAME, VALID_PHONE, VALID_EMAIL,
-                INVALID_ADDRESS, VALID_TAGS, VALID_REMARK, false, VALID_TOTAL_SALES_AMOUNT);
+                INVALID_ADDRESS, VALID_TAGS, VALID_REMARK, false);
         String expectedMessage = Address.MESSAGE_CONSTRAINTS;
         assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
@@ -107,7 +104,7 @@ public class JsonAdaptedPersonTest {
     @Test
     public void toModelType_nullAddress_throwsIllegalValueException() {
         JsonAdaptedPerson person = new JsonAdaptedPerson(VALID_ID, VALID_NAME, VALID_PHONE, VALID_EMAIL, null,
-                VALID_TAGS, VALID_REMARK, false, VALID_TOTAL_SALES_AMOUNT);
+                VALID_TAGS, VALID_REMARK, false);
         String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT, Address.class.getSimpleName());
         assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
@@ -117,43 +114,7 @@ public class JsonAdaptedPersonTest {
         List<JsonAdaptedTag> invalidTags = new ArrayList<>(VALID_TAGS);
         invalidTags.add(new JsonAdaptedTag(INVALID_TAG));
         JsonAdaptedPerson person = new JsonAdaptedPerson(VALID_ID, VALID_NAME, VALID_PHONE, VALID_EMAIL, VALID_ADDRESS,
-                invalidTags, VALID_REMARK, false, VALID_TOTAL_SALES_AMOUNT);
+                invalidTags, VALID_REMARK, false);
         assertThrows(IllegalValueException.class, person::toModelType);
-    }
-
-    @Test
-    public void toModelType_invalidTotalSalesAmount_throwsIllegalValueException() {
-        JsonAdaptedPerson person1 = new JsonAdaptedPerson(VALID_ID, VALID_NAME, VALID_PHONE, VALID_EMAIL,
-                VALID_ADDRESS, VALID_TAGS, VALID_REMARK, false, INVALID_TOTAL_SALES_AMOUNT_1);
-        JsonAdaptedPerson person2 = new JsonAdaptedPerson(VALID_ID, VALID_NAME, VALID_PHONE, VALID_EMAIL,
-                VALID_ADDRESS, VALID_TAGS, VALID_REMARK, false, INVALID_TOTAL_SALES_AMOUNT_2);
-        JsonAdaptedPerson person3 = new JsonAdaptedPerson(VALID_ID, VALID_NAME, VALID_PHONE, VALID_EMAIL,
-                VALID_ADDRESS, VALID_TAGS, VALID_REMARK, false, INVALID_TOTAL_SALES_AMOUNT_3);
-        String expectedMessage = "Total Sales Amount should be a positive decimal number, "
-                + "with at most 2 decimal places.";
-        assertThrows(IllegalValueException.class, expectedMessage, person1::toModelType);
-        assertThrows(IllegalValueException.class, expectedMessage, person2::toModelType);
-        assertThrows(IllegalValueException.class, expectedMessage, person3::toModelType);
-    }
-
-    @Test
-    public void toModelType_nullTotalSalesAmount_throwsIllegalValueException() {
-        JsonAdaptedPerson person = new JsonAdaptedPerson(VALID_ID, VALID_NAME, VALID_PHONE, VALID_EMAIL, VALID_ADDRESS,
-                VALID_TAGS, VALID_REMARK, false, null);
-        String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT, "Total Sales Amount");
-        assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
-    }
-
-    @Test
-    public void toModelType_zeroTotalSalesAmount_returnsPerson() throws Exception {
-        JsonAdaptedPerson person1 = new JsonAdaptedPerson(VALID_ID, VALID_NAME, VALID_PHONE, VALID_EMAIL, VALID_ADDRESS,
-                VALID_TAGS, VALID_REMARK, false, ZERO_TOTAL_SALES_AMOUNT_1);
-        JsonAdaptedPerson person2 = new JsonAdaptedPerson(VALID_ID, VALID_NAME, VALID_PHONE, VALID_EMAIL, VALID_ADDRESS,
-                VALID_TAGS, VALID_REMARK, false, ZERO_TOTAL_SALES_AMOUNT_2);
-
-        assertEquals(new PersonBuilder(BENSON).withTotalSalesAmount(new BigDecimal("0")).build(),
-                person1.toModelType());
-        assertEquals(new PersonBuilder(BENSON).withTotalSalesAmount(new BigDecimal("0")).build(),
-                person2.toModelType());
     }
 }

--- a/src/test/java/seedu/address/storage/JsonAdaptedPersonTest.java
+++ b/src/test/java/seedu/address/storage/JsonAdaptedPersonTest.java
@@ -5,7 +5,6 @@ import static seedu.address.storage.JsonAdaptedPerson.MISSING_FIELD_MESSAGE_FORM
 import static seedu.address.testutil.Assert.assertThrows;
 import static seedu.address.testutil.person.TypicalPersons.BENSON;
 
-import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -17,7 +16,6 @@ import seedu.address.model.person.Address;
 import seedu.address.model.person.Email;
 import seedu.address.model.person.Name;
 import seedu.address.model.person.Phone;
-import seedu.address.testutil.person.PersonBuilder;
 
 public class JsonAdaptedPersonTest {
     private static final String INVALID_NAME = "R@chel";
@@ -25,9 +23,6 @@ public class JsonAdaptedPersonTest {
     private static final String INVALID_ADDRESS = " ";
     private static final String INVALID_EMAIL = "example.com";
     private static final String INVALID_TAG = "#friend";
-    private static final String INVALID_TOTAL_SALES_AMOUNT_1 = "str";
-    private static final String INVALID_TOTAL_SALES_AMOUNT_2 = "-1";
-    private static final String INVALID_TOTAL_SALES_AMOUNT_3 = "-1";
 
     private static final Integer VALID_ID = BENSON.getId();
     private static final String VALID_NAME = BENSON.getName().toString();

--- a/src/test/java/seedu/address/testutil/person/PersonBuilder.java
+++ b/src/test/java/seedu/address/testutil/person/PersonBuilder.java
@@ -34,7 +34,6 @@ public class PersonBuilder {
     private Set<Tag> tags;
     private Remark remark;
     private boolean archived;
-    private BigDecimal totalSalesAmount;
 
     /**
      * Creates a {@code PersonBuilder} with the default details.
@@ -48,7 +47,6 @@ public class PersonBuilder {
         tags = new HashSet<>();
         remark = DEFAULT_REMARK;
         archived = false;
-        totalSalesAmount = DEFAULT_TOTAL_SALES_AMOUNT;
     }
 
 
@@ -64,7 +62,6 @@ public class PersonBuilder {
         tags = new HashSet<>(personToCopy.getTags());
         remark = personToCopy.getRemark();
         archived = personToCopy.isArchived();
-        totalSalesAmount = personToCopy.getTotalSalesAmount();
     }
 
     /**
@@ -124,7 +121,6 @@ public class PersonBuilder {
     }
 
     /**
-<<<<<<< HEAD
      * Sets the {@code Archived} of the {@code Person} that we are building to {@code true}.
      */
     public PersonBuilder withArchived() {
@@ -132,19 +128,8 @@ public class PersonBuilder {
         return this;
     }
 
-    /**
-     * Adds the {@code sales} into a {@code UniqueSaleList} and set it to the {@code Person} that we are building.
-=======
-     * Sets the {@code Remark} of the {@code Person} that we are building.
->>>>>>> master
-     */
-    public PersonBuilder withTotalSalesAmount(BigDecimal totalSalesAmount) {
-        this.totalSalesAmount = totalSalesAmount;
-        return this;
-    }
-
     public Person build() {
-        return new Person(id, name, phone, email, address, tags, remark, archived, totalSalesAmount);
+        return new Person(id, name, phone, email, address, tags, remark, archived);
     }
 
 }

--- a/src/test/java/seedu/address/testutil/person/TypicalPersons.java
+++ b/src/test/java/seedu/address/testutil/person/TypicalPersons.java
@@ -13,7 +13,6 @@ import static seedu.address.logic.commands.CommandTestUtil.VALID_REMARK_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_TAG_FRIEND;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_TAG_HUSBAND;
 
-import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;

--- a/src/test/java/seedu/address/testutil/person/TypicalPersons.java
+++ b/src/test/java/seedu/address/testutil/person/TypicalPersons.java
@@ -29,14 +29,12 @@ public class TypicalPersons {
 
     public static final Person ALICE = new PersonBuilder().withId(1).withName("Alice Pauline")
         .withAddress("123, Jurong West Ave 6, #08-111").withEmail("alice@example.com").withPhone("94351253")
-        .withTags("friends").withRemark("Likes chocolates").withTotalSalesAmount(new BigDecimal("0.8")).build();
+        .withTags("friends").withRemark("Likes chocolates").build();
     public static final Person BENSON = new PersonBuilder().withId(2).withName("Benson Meier")
         .withAddress("311, Clementi Ave 2, #02-25").withEmail("johnd@example.com").withPhone("98765432")
-        .withTags("owesMoney", "friends").withRemark("Owes me $10")
-        .withTotalSalesAmount(new BigDecimal("35.00")).build();
+        .withTags("owesMoney", "friends").withRemark("Owes me $10").build();
     public static final Person CARL = new PersonBuilder().withId(3).withName("Carl Kurz").withPhone("95352563")
-        .withEmail("heinz@example.com").withAddress("wall street")
-        .withTotalSalesAmount(new BigDecimal("2001.00")).build();
+        .withEmail("heinz@example.com").withAddress("wall street").build();
     public static final Person DANIEL = new PersonBuilder().withId(4).withName("Daniel Meier").withPhone("87652533")
         .withEmail("cornelia@example.com").withAddress("10th street").withTags("friends").build();
     public static final Person ELLE = new PersonBuilder().withId(5).withName("Elle Meyer")


### PR DESCRIPTION
The current implementation involves:
- `Sale` objects, which contain a `Person`
- `Person` objects, which contain `totalSaleAmount`

When a sale quantity/unit price is edited, the total sale amount of the sale would change. This means the buyer associated with the sale would need to be edited before the edited sale can be created and replace the original sale.

This problem is compounded by the facts that the buyer of the sale can be edited, and that mass commands allow for multiple sales to be edited, resulting in very high code complexity. 

This results in a high level of coupling and thus high complexity, reducing the maintainability of the code.
I discussed with Aaron, and we agreed to remove the totalSaleAmount feature.