### PR TITLE
Fix bug in sale breakdown command

### DIFF
--- a/src/main/java/seedu/address/commons/dataset/tag/SaleTagCountData.java
+++ b/src/main/java/seedu/address/commons/dataset/tag/SaleTagCountData.java
@@ -1,5 +1,7 @@
 package seedu.address.commons.dataset.tag;
 
+import static java.util.Objects.requireNonNull;
+
 import java.util.Objects;
 
 import seedu.address.commons.dataset.Data;

--- a/src/main/java/seedu/address/commons/dataset/tag/SaleTagCountData.java
+++ b/src/main/java/seedu/address/commons/dataset/tag/SaleTagCountData.java
@@ -1,7 +1,5 @@
 package seedu.address.commons.dataset.tag;
 
-import static java.util.Objects.requireNonNull;
-
 import java.util.Objects;
 
 import seedu.address.commons.dataset.Data;

--- a/src/main/java/seedu/address/commons/dataset/tag/SaleTagListMap.java
+++ b/src/main/java/seedu/address/commons/dataset/tag/SaleTagListMap.java
@@ -1,5 +1,8 @@
 package seedu.address.commons.dataset.tag;
 
+import static java.util.Objects.requireNonNull;
+import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
+
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
@@ -11,6 +14,7 @@ import java.util.stream.Collectors;
 
 import seedu.address.commons.dataset.Data;
 import seedu.address.commons.dataset.DataSet;
+import seedu.address.commons.util.JsonUtil;
 import seedu.address.model.sale.Sale;
 import seedu.address.model.tag.Tag;
 
@@ -31,6 +35,7 @@ public class SaleTagListMap {
      * @param sale A valid sale to be added.
      */
     public void addSale(Sale sale) {
+        requireNonNull(sale);
         Set<Tag> tags = sale.getTags();
 
         tags.forEach(tag -> {
@@ -49,6 +54,8 @@ public class SaleTagListMap {
      * @param sale The sale to be removed.
      */
     public void removeSale(Sale sale) {
+        requireNonNull(sale);
+
         Set<Tag> tags = sale.getTags();
 
         tags.forEach(tag -> {
@@ -71,6 +78,8 @@ public class SaleTagListMap {
      * @return The number of sales with that tag.
      */
     public int getSaleCount(Tag tag) {
+        requireNonNull(tag);
+
         TagKey key = new TagKey(tag);
         if (this.saleTagListMap.containsKey(key)) {
             return this.saleTagListMap.get(key).size();
@@ -84,6 +93,7 @@ public class SaleTagListMap {
      * @param tag The tag to be removed.
      */
     public void removeTag(Tag tag) {
+        requireNonNull(tag);
         TagKey key = new TagKey(tag);
         saleTagListMap.remove(key);
     }
@@ -95,6 +105,7 @@ public class SaleTagListMap {
      * @param newTag The newly edited tag to replace.
      */
     public void editTag(Tag previousTag, Tag newTag) {
+        requireAllNonNull(previousTag, newTag);
         TagKey tagKeyToEdit = saleTagListMap.keySet().stream()
                 .filter(tagKey -> tagKey.getTag().equals(previousTag))
                 .findFirst().orElseThrow();
@@ -118,7 +129,7 @@ public class SaleTagListMap {
         List<SaleTagCountData> result = new ArrayList<>();
 
         saleTagListMap.forEach(((tagKey, sales) -> {
-            result.add(new SaleTagCountData(tagKey, getSaleCount(tagKey.getTag())));
+            result.add(new SaleTagCountData(tagKey, sales.size()));
         }));
 
         result.sort(Comparator.comparingInt(Data::getCount));

--- a/src/main/java/seedu/address/commons/dataset/tag/SaleTagListMap.java
+++ b/src/main/java/seedu/address/commons/dataset/tag/SaleTagListMap.java
@@ -109,7 +109,8 @@ public class SaleTagListMap {
     }
 
     /**
-     * Gets the sale counts in the sale list for every {@code tag}.
+     * Gets the sale counts in the sale list for the top 5 {@code tag}.
+     * If tag does not have any sales assigned, it will not be included.
      *
      * @return A DataSet object containing SaleTagCountData.
      */
@@ -121,8 +122,9 @@ public class SaleTagListMap {
         }));
 
         result.sort(Comparator.comparingInt(Data::getCount));
-        List<SaleTagCountData> topSaleTagCountData = result.stream().limit(5).
-                collect(Collectors.toList());
+        List<SaleTagCountData> topSaleTagCountData = result.stream()
+                .filter(data -> data.getCount() > 0).limit(5)
+                .collect(Collectors.toList());
         Collections.reverse(topSaleTagCountData);
 
         return new DataSet<>(topSaleTagCountData);

--- a/src/main/java/seedu/address/commons/dataset/tag/SaleTagListMap.java
+++ b/src/main/java/seedu/address/commons/dataset/tag/SaleTagListMap.java
@@ -9,12 +9,12 @@ import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 
 import seedu.address.commons.dataset.Data;
 import seedu.address.commons.dataset.DataSet;
-import seedu.address.commons.util.JsonUtil;
 import seedu.address.model.sale.Sale;
 import seedu.address.model.tag.Tag;
 
@@ -70,6 +70,7 @@ public class SaleTagListMap {
         });
     }
 
+    // TODO: potentially remove
     /**
      * Gets the number of items in an sale list based on the key of {@code key}.
      * If the key of {@code key} does not exist, the number is 0.
@@ -79,12 +80,9 @@ public class SaleTagListMap {
      */
     public int getSaleCount(Tag tag) {
         requireNonNull(tag);
-
         TagKey key = new TagKey(tag);
-        if (this.saleTagListMap.containsKey(key)) {
-            return this.saleTagListMap.get(key).size();
-        }
-        return 0;
+        assert this.saleTagListMap.containsKey(key);
+        return this.saleTagListMap.get(key).size();
     }
 
     /**
@@ -106,9 +104,13 @@ public class SaleTagListMap {
      */
     public void editTag(Tag previousTag, Tag newTag) {
         requireAllNonNull(previousTag, newTag);
-        TagKey tagKeyToEdit = saleTagListMap.keySet().stream()
+        Optional<TagKey> possibleTagKeyToEdit = saleTagListMap.keySet().stream()
                 .filter(tagKey -> tagKey.getTag().equals(previousTag))
-                .findFirst().orElseThrow();
+                .findFirst();
+
+        assert possibleTagKeyToEdit.isPresent();
+
+        TagKey tagKeyToEdit = possibleTagKeyToEdit.get();
         tagKeyToEdit.setTag(newTag);
     }
 

--- a/src/main/java/seedu/address/commons/dataset/tag/SaleTagListMap.java
+++ b/src/main/java/seedu/address/commons/dataset/tag/SaleTagListMap.java
@@ -28,7 +28,7 @@ public class SaleTagListMap {
     /**
      * Adds {@code sale} to an sale list based on the key of {@code tag}.
      *
-     * @param sale a valid year sale.
+     * @param sale A valid sale to be added.
      */
     public void addSale(Sale sale) {
         Set<Tag> tags = sale.getTags();
@@ -46,7 +46,7 @@ public class SaleTagListMap {
     /**
      * Removes {@code sale} from an sale list based on the key of {@code key} if exists.
      *
-     * @param sale a valid year sale
+     * @param sale The sale to be removed.
      */
     public void removeSale(Sale sale) {
         Set<Tag> tags = sale.getTags();
@@ -67,8 +67,8 @@ public class SaleTagListMap {
      * Gets the number of items in an sale list based on the key of {@code key}.
      * If the key of {@code key} does not exist, the number is 0.
      *
-     * @param tag a valid month tag.
-     * @return the number of sales with that tag.
+     * @param tag A valid tag.
+     * @return The number of sales with that tag.
      */
     public int getSaleCount(Tag tag) {
         TagKey key = new TagKey(tag);
@@ -79,14 +79,26 @@ public class SaleTagListMap {
     }
 
     /**
-     * Gets the list of sales with a specific {@code tag}.
+     * Remove a tag from the saleTagListMap.
      *
-     * @param tag a valid month tag.
-     * @return list of sales in its natural order
+     * @param tag The tag to be removed.
      */
-    public List<Sale> getSales(Tag tag) {
+    public void removeTag(Tag tag) {
         TagKey key = new TagKey(tag);
-        return this.saleTagListMap.getOrDefault(key, Collections.emptyList());
+        saleTagListMap.remove(key);
+    }
+
+    /**
+     * Edit a tagKey to contain the newly edited tag.
+     *
+     * @param previousTag The tag to be replaced.
+     * @param newTag The newly edited tag to replace.
+     */
+    public void editTag(Tag previousTag, Tag newTag) {
+        TagKey tagKeyToEdit = saleTagListMap.keySet().stream()
+                .filter(tagKey -> tagKey.getTag().equals(previousTag))
+                .findFirst().orElseThrow();
+        tagKeyToEdit.setTag(newTag);
     }
 
     /**
@@ -109,7 +121,8 @@ public class SaleTagListMap {
         }));
 
         result.sort(Comparator.comparingInt(Data::getCount));
-        List<SaleTagCountData> topSaleTagCountData = result.stream().limit(5).collect(Collectors.toList());
+        List<SaleTagCountData> topSaleTagCountData = result.stream().limit(5).
+                collect(Collectors.toList());
         Collections.reverse(topSaleTagCountData);
 
         return new DataSet<>(topSaleTagCountData);

--- a/src/main/java/seedu/address/commons/dataset/tag/TagKey.java
+++ b/src/main/java/seedu/address/commons/dataset/tag/TagKey.java
@@ -1,5 +1,7 @@
 package seedu.address.commons.dataset.tag;
 
+import static java.util.Objects.requireNonNull;
+
 import java.util.Objects;
 
 import seedu.address.model.tag.Tag;
@@ -8,6 +10,7 @@ public class TagKey {
     private Tag tag;
 
     public TagKey(Tag tag) {
+        requireNonNull(tag);
         this.tag = tag;
     }
 
@@ -16,6 +19,7 @@ public class TagKey {
     }
 
     public void setTag(Tag tag) {
+        requireNonNull(tag);
         this.tag = tag;
     }
 

--- a/src/main/java/seedu/address/commons/dataset/tag/TagKey.java
+++ b/src/main/java/seedu/address/commons/dataset/tag/TagKey.java
@@ -9,6 +9,10 @@ import seedu.address.model.tag.Tag;
 public class TagKey {
     private Tag tag;
 
+    /**
+     * Creates a TagKey with the specified {@code tag}.
+     * @param tag The tag to be stored in the TagKey.
+     */
     public TagKey(Tag tag) {
         requireNonNull(tag);
         this.tag = tag;

--- a/src/main/java/seedu/address/model/sale/UniqueSaleList.java
+++ b/src/main/java/seedu/address/model/sale/UniqueSaleList.java
@@ -184,6 +184,8 @@ public class UniqueSaleList implements Iterable<Sale> {
     public void setSaleTag(Tag target, Tag editedTag) {
         requireAllNonNull(target, editedTag);
         int count = internalList.size();
+        saleTagListMap.editTag(target, editedTag);
+
         // Iterate through all sales and update their tags.
         for (int i = 0; i < count; i++) {
             Sale original = internalList.get(i);
@@ -201,7 +203,6 @@ public class UniqueSaleList implements Iterable<Sale> {
                 internalList.set(i, newSale);
                 monthlyListMap.removeItem(original.getMonth(), original.getYear(), original);
                 monthlyListMap.addItem(newSale.getMonth(), newSale.getYear(), newSale);
-                saleTagListMap.editTag(target, editedTag);
             }
         }
     }
@@ -211,8 +212,9 @@ public class UniqueSaleList implements Iterable<Sale> {
      */
     public void removeSaleTag(Tag toRemove) {
         requireNonNull(toRemove);
-        int count = internalList.size();
+        saleTagListMap.removeTag(toRemove);
 
+        int count = internalList.size();
         for (int i = 0; i < count; i++) {
             Sale original = internalList.get(i);
             Set<Tag> tags = new HashSet<>(original.getTags());
@@ -229,7 +231,6 @@ public class UniqueSaleList implements Iterable<Sale> {
                         original.getYear(), original);
                 monthlyListMap.addItem(newSale.getMonth(),
                         newSale.getYear(), newSale);
-                saleTagListMap.removeTag(toRemove);
             }
         }
     }

--- a/src/main/java/seedu/address/model/sale/UniqueSaleList.java
+++ b/src/main/java/seedu/address/model/sale/UniqueSaleList.java
@@ -199,10 +199,9 @@ public class UniqueSaleList implements Iterable<Sale> {
                         original.getUnitPrice(),
                         tags);
                 internalList.set(i, newSale);
-                monthlyListMap.removeItem(original.getMonth(),
-                        original.getYear(), original);
-                monthlyListMap.addItem(newSale.getMonth(),
-                        newSale.getYear(), newSale);
+                monthlyListMap.removeItem(original.getMonth(), original.getYear(), original);
+                monthlyListMap.addItem(newSale.getMonth(), newSale.getYear(), newSale);
+                saleTagListMap.editTag(target, editedTag);
             }
         }
     }
@@ -230,6 +229,7 @@ public class UniqueSaleList implements Iterable<Sale> {
                         original.getYear(), original);
                 monthlyListMap.addItem(newSale.getMonth(),
                         newSale.getYear(), newSale);
+                saleTagListMap.removeTag(toRemove);
             }
         }
     }

--- a/src/test/java/seedu/address/commons/dataset/DataSetTest.java
+++ b/src/test/java/seedu/address/commons/dataset/DataSetTest.java
@@ -28,7 +28,6 @@ class DataSetTest {
         monthlyCountDataSet = new DataSet<>(monthlyCountDataList);
     }
 
-
     @Test
     public void getTestAndSetTest_valid_success() {
         String expectedTitle = "test 1";

--- a/src/test/java/seedu/address/commons/dataset/date/MonthlyCountDataTest.java
+++ b/src/test/java/seedu/address/commons/dataset/date/MonthlyCountDataTest.java
@@ -26,7 +26,7 @@ public class MonthlyCountDataTest {
     }
 
     @Test
-    public void getMonthAndYearAsStr_valid_success() {
+    public void getKeyAsStr_valid_success() {
         String expectedString = String.format("%s %s", AUGUST, Year.now());
         MonthlyCountData monthlyCountData =
                 new MonthlyCountData(new MonthAndYear(AUGUST, Year.now()), 1);

--- a/src/test/java/seedu/address/commons/dataset/tag/SaleTagCountDataTest.java
+++ b/src/test/java/seedu/address/commons/dataset/tag/SaleTagCountDataTest.java
@@ -1,0 +1,49 @@
+package seedu.address.commons.dataset.tag;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static seedu.address.testutil.Assert.assertThrows;
+import static seedu.address.testutil.TypicalSaleTags.IMPORTANT;
+import static seedu.address.testutil.TypicalSaleTags.PENDING;
+
+import org.junit.jupiter.api.Test;
+
+public class SaleTagCountDataTest {
+
+    private final SaleTagCountData saleTagCountData =
+            new SaleTagCountData(new TagKey(IMPORTANT), 1);
+
+    @Test
+    public void constructor_nullInput_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> new SaleTagCountData(null, 1));
+    }
+
+    @Test
+    public void getCount_valid_success() {
+        assertEquals(1, this.saleTagCountData.getCount());
+    }
+
+    @Test
+    public void getKeyAsStr_valid_success() {
+        assertEquals(IMPORTANT.getTagName(), saleTagCountData.getKeyAsStr());
+    }
+
+    @Test
+    public void equals_valid_success() {
+        assertEquals(saleTagCountData, saleTagCountData);
+
+        SaleTagCountData saleTagCountData1 = new SaleTagCountData(new TagKey(IMPORTANT), 1);
+        assertEquals(saleTagCountData, saleTagCountData1);
+
+        saleTagCountData1 = new SaleTagCountData(new TagKey(IMPORTANT), 2);
+        assertNotEquals(saleTagCountData, saleTagCountData1);
+
+        saleTagCountData1 = new SaleTagCountData(new TagKey(PENDING), 1);
+        assertNotEquals(saleTagCountData, saleTagCountData1);
+
+        saleTagCountData1 = new SaleTagCountData(new TagKey(PENDING), 2);
+        assertNotEquals(saleTagCountData, saleTagCountData1);
+
+        assertNotEquals(saleTagCountData, null);
+    }
+}

--- a/src/test/java/seedu/address/commons/dataset/tag/TagKeyTest.java
+++ b/src/test/java/seedu/address/commons/dataset/tag/TagKeyTest.java
@@ -1,0 +1,48 @@
+package seedu.address.commons.dataset.tag;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static seedu.address.testutil.Assert.assertThrows;
+import static seedu.address.testutil.TypicalSaleTags.FOLLOW_UP;
+import static seedu.address.testutil.TypicalSaleTags.IMPORTANT;
+
+import org.junit.jupiter.api.Test;
+
+public class TagKeyTest {
+
+    private final TagKey tagKey = new TagKey(IMPORTANT);
+
+    @Test
+    public void constructor_nullInput_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> new TagKey(null));
+    }
+
+    @Test
+    public void getTag_valid_success() {
+        assertEquals(IMPORTANT, this.tagKey.getTag());
+    }
+
+    @Test
+    public void setTag_nullInput_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> tagKey.setTag(null));
+    }
+
+    @Test
+    public void setTag_valid_success() {
+        tagKey.setTag(FOLLOW_UP);
+        assertEquals(FOLLOW_UP, tagKey.getTag());
+    }
+
+    @Test
+    public void equals_valid_success() {
+        assertEquals(tagKey, tagKey);
+
+        TagKey tagKey1 = new TagKey(IMPORTANT);
+        assertEquals(tagKey, tagKey1);
+
+        tagKey1 = new TagKey(FOLLOW_UP);
+        assertNotEquals(tagKey, tagKey1);
+
+        assertNotEquals(tagKey, null);
+    }
+}


### PR DESCRIPTION
**Changes Made**
- Previously, when tags are deleted/updated, `SaleTagListMap` is not updated, resulting in an incorrect chart being shown.
    - This PR fixes the above issue
- Fixing of JavaDocs capitalisation
- Addition of test cases for TagKey and SaleTagCountData
- Code Quality improvements