### PR TITLE
Fix sale edit

### DIFF
--- a/src/main/java/seedu/address/logic/commands/sale/EditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/sale/EditCommand.java
@@ -57,6 +57,7 @@ public class EditCommand extends Command {
     public static final String MESSAGE_EDIT_SALE_FAILED = "No sales edited.";
     public static final String MESSAGE_NOT_EDITED = "At least one field to edit must be provided.";
     public static final String MESSAGE_DUPLICATE_SALE = "This sale already exists in the address book.";
+    public static final String MESSAGES_SALES_MISSING_TAGS = "All sales must contain at least one tag.";
 
     private final List<Index> saleIndexes;
     private final Index personIndex;

--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -7,6 +7,7 @@ import static seedu.address.commons.core.Messages.MESSAGE_INVALID_MONTH;
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_NUMBER_OF_MONTHS;
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_REMINDER_STATUS;
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_YEAR;
+import static seedu.address.logic.commands.sale.EditCommand.MESSAGES_SALES_MISSING_TAGS;
 
 import java.math.BigDecimal;
 import java.time.DateTimeException;
@@ -169,6 +170,12 @@ public class ParserUtil {
      */
     public static Set<Tag> parseTags(Collection<String> tags) throws ParseException {
         requireNonNull(tags);
+
+        // Prefix present with no tags specified (t/)
+        if (tags.size() == 1 && tags.contains("")) {
+            throw new ParseException(MESSAGES_SALES_MISSING_TAGS);
+        }
+
         final Set<Tag> tagSet = new HashSet<>();
         for (String tagName : tags) {
             tagSet.add(parseTag(tagName));

--- a/src/main/java/seedu/address/logic/parser/sale/EditCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/sale/EditCommandParser.java
@@ -2,7 +2,6 @@ package seedu.address.logic.parser.sale;
 
 import static java.util.Objects.requireNonNull;
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
-import static seedu.address.logic.commands.sale.EditCommand.MESSAGES_SALES_MISSING_TAGS;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_SALE_CONTACT_INDEX;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_SALE_DATE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_SALE_INDEX;
@@ -13,7 +12,6 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
 import static seedu.address.logic.parser.ParserUtil.arePrefixesPresent;
 
 import java.util.Collection;
-import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;

--- a/src/main/java/seedu/address/logic/parser/sale/EditCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/sale/EditCommandParser.java
@@ -2,6 +2,7 @@ package seedu.address.logic.parser.sale;
 
 import static java.util.Objects.requireNonNull;
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.commands.sale.EditCommand.MESSAGES_SALES_MISSING_TAGS;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_SALE_CONTACT_INDEX;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_SALE_DATE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_SALE_INDEX;
@@ -93,11 +94,12 @@ public class EditCommandParser implements Parser<EditCommand> {
     private Optional<Set<Tag>> parseTagsForEdit(Collection<String> tags) throws ParseException {
         assert tags != null;
 
+        // No prefix with no tags specified
         if (tags.isEmpty()) {
             return Optional.empty();
         }
-        Collection<String> tagSet = tags.size() == 1 && tags.contains("") ? Collections.emptySet() : tags;
-        return Optional.of(ParserUtil.parseTags(tagSet));
+
+        return Optional.of(ParserUtil.parseTags(tags));
     }
 
 }

--- a/src/test/java/seedu/address/logic/parser/sale/EditCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/sale/EditCommandParserTest.java
@@ -222,15 +222,4 @@ public class EditCommandParserTest {
         expectedCommand = new EditCommand(new ArrayList<>(Arrays.asList(targetIndex)), descriptor, null);
         assertParseSuccess(parser, userInput, expectedCommand);
     }
-
-    @Test
-    public void parse_resetTags_success() {
-        Index targetIndex = INDEX_THIRD_ITEM;
-        String userInput = " " + PREFIX_SALE_INDEX.toString() + targetIndex.getOneBased() + TAG_EMPTY;
-
-        EditSaleDescriptor descriptor = new EditSaleDescriptorBuilder().withTags().build();
-        EditCommand expectedCommand = new EditCommand(new ArrayList<>(Arrays.asList(targetIndex)), descriptor, null);
-
-        assertParseSuccess(parser, userInput, expectedCommand);
-    }
 }


### PR DESCRIPTION
Closes #179 

**Changes Made**
- Fix EditCommand to throw an Exception if no tags are specified

<img width="1552" alt="Screenshot 2020-10-29 at 3 23 55 PM" src="https://user-images.githubusercontent.com/54730257/97538706-d1117500-19fb-11eb-85a5-fbdc254794a2.png">


**Future Improvements**
- Add test cases ensuring all sales will have tags after edit