### PR TITLE
Fix failing test cases

### DIFF
--- a/src/test/java/seedu/address/logic/commands/meeting/EditCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/meeting/EditCommandTest.java
@@ -53,6 +53,7 @@ public class EditCommandTest {
         String expectedMessage = String.format(EditCommand.MESSAGE_EDIT_MEETING_SUCCESS, editedMeeting);
 
         Model expectedModel = new ModelManager(new AddressBook(model.getAddressBook()), new UserPrefs());
+        expectedModel.updateFilteredMeetingList(PREDICATE_SHOW_ALL_MEETINGS);
         expectedModel.setMeeting(model.getSortedMeetingList().get(0), editedMeeting);
 
         assertCommandSuccess(editCommand, model, expectedMessage, expectedModel);
@@ -79,8 +80,8 @@ public class EditCommandTest {
         String expectedMessage = String.format(EditCommand.MESSAGE_EDIT_MEETING_SUCCESS, editedMeeting);
 
         Model expectedModel = new ModelManager(new AddressBook(model.getAddressBook()), new UserPrefs());
+        expectedModel.updateFilteredMeetingList(PREDICATE_SHOW_ALL_MEETINGS);
         expectedModel.setMeeting(lastMeeting, editedMeeting);
-
         assertCommandSuccess(editCommand, model, expectedMessage, expectedModel);
     }
 
@@ -94,7 +95,7 @@ public class EditCommandTest {
         String expectedMessage = String.format(EditCommand.MESSAGE_EDIT_MEETING_SUCCESS, editedMeeting);
 
         Model expectedModel = new ModelManager(new AddressBook(model.getAddressBook()), new UserPrefs());
-
+        expectedModel.updateFilteredMeetingList(PREDICATE_SHOW_ALL_MEETINGS);
         assertCommandSuccess(editCommand, model, expectedMessage, expectedModel);
     }
 

--- a/src/test/java/seedu/address/logic/commands/meeting/EditCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/meeting/EditCommandTest.java
@@ -6,6 +6,7 @@ import static seedu.address.logic.commands.CommandTestUtil.VALID_MESSAGE_CALL_AM
 import static seedu.address.logic.commands.CommandTestUtil.VALID_MESSAGE_CALL_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandFailure;
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
+import static seedu.address.model.Model.PREDICATE_SHOW_ALL_MEETINGS;
 import static seedu.address.testutil.TypicalAddressBook.getTypicalAddressBookInReverse;
 import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_ITEM;
 import static seedu.address.testutil.TypicalIndexes.INDEX_SECOND_ITEM;
@@ -36,8 +37,10 @@ public class EditCommandTest {
 
     @Test
     public void execute_allFieldsSpecifiedUnfilteredList_success() {
-        Meeting editedMeeting = new Meeting(GEORGE, new Message(VALID_MESSAGE_CALL_AMY),
-                TypicalDates.TYPICAL_DATE_3, TypicalDurations.TYPICAL_DURATION_ONE_HOUR);
+        model.updateFilteredMeetingList(PREDICATE_SHOW_ALL_MEETINGS);
+
+        Meeting editedMeeting = new Meeting(GEORGE, new Message(VALID_MESSAGE_CALL_AMY), TypicalDates.TYPICAL_DATE_3,
+                TypicalDurations.TYPICAL_DURATION_ONE_HOUR);
         EditMeetingDescriptor descriptor = new EditMeetingDescriptorBuilder()
                 // George appears as the 6th item
                 .withContactIndex(Index.fromZeroBased(6))
@@ -57,6 +60,8 @@ public class EditCommandTest {
 
     @Test
     public void execute_someFieldsSpecifiedUnfilteredList_success() {
+        model.updateFilteredMeetingList(PREDICATE_SHOW_ALL_MEETINGS);
+
         Index indexLastMeeting = Index.fromOneBased(model.getSortedMeetingList().size());
         Meeting lastMeeting = model.getSortedMeetingList().get(indexLastMeeting.getZeroBased());
 
@@ -81,6 +86,8 @@ public class EditCommandTest {
 
     @Test
     public void execute_noFieldSpecifiedUnfilteredList_success() {
+        model.updateFilteredMeetingList(PREDICATE_SHOW_ALL_MEETINGS);
+
         EditCommand editCommand = new EditCommand(INDEX_FIRST_ITEM, new EditMeetingDescriptor());
         Meeting editedMeeting = model.getSortedMeetingList().get(INDEX_FIRST_ITEM.getZeroBased());
 
@@ -93,6 +100,8 @@ public class EditCommandTest {
 
     @Test
     public void execute_duplicateMeetingUnfilteredList_failure() {
+        model.updateFilteredMeetingList(PREDICATE_SHOW_ALL_MEETINGS);
+
         Meeting firstMeeting = model.getSortedMeetingList().get(INDEX_FIRST_ITEM.getZeroBased());
         EditMeetingDescriptor descriptor = new EditMeetingDescriptorBuilder()
                 .withContactIndex(Index.fromZeroBased(model.getSortedPersonList().indexOf(firstMeeting.getPerson())))
@@ -107,6 +116,8 @@ public class EditCommandTest {
 
     @Test
     public void execute_invalidMeetingIndexUnfilteredList_failure() {
+        model.updateFilteredMeetingList(PREDICATE_SHOW_ALL_MEETINGS);
+
         Index outOfBoundIndex = Index.fromOneBased(model.getSortedMeetingList().size() + 1);
         EditMeetingDescriptor descriptor =
                 new EditMeetingDescriptorBuilder().withMessage(VALID_MESSAGE_CALL_BOB).build();


### PR DESCRIPTION
Tests only started failing because the tests were executing on the filtered list (which shows only upcoming meetings and some of our test data included meetings that were over)