### PR TITLE
Fix duplicate contact issues

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -85,6 +85,7 @@ Adds a contact to StonksBook.
 :bulb: Tip: A contact can have any number of tags (including 0)
 
 * The contact tags provided must exist in StonksBook before you can associate this contact with them.
+* Duplicate contacts cannot be added. A contact with the same name and same phone number/email address will be flagged as a duplicate.
 
 **Examples**:
 * `contact add n/John Doe p/98765432 e/johnd@example.com a/John street, block 123, #01-01`

--- a/src/main/java/seedu/address/logic/commands/contact/DeleteCommand.java
+++ b/src/main/java/seedu/address/logic/commands/contact/DeleteCommand.java
@@ -24,7 +24,7 @@ public class DeleteCommand extends Command {
             + "Parameters: INDEX (must be a positive integer)\n"
             + "Example: " + COMMAND_WORD + " 1";
 
-    public static final String MESSAGE_DELETE_PERSON_SUCCESS = "Deleted Person: %1$s. All associated meetings and "
+    public static final String MESSAGE_DELETE_PERSON_SUCCESS = "Deleted Person: %1$s.\nAll associated meetings and "
             + "reminders have been deleted as well.";
 
     private final Index targetIndex;

--- a/src/main/java/seedu/address/model/AddressBook.java
+++ b/src/main/java/seedu/address/model/AddressBook.java
@@ -321,7 +321,7 @@ public class AddressBook implements ReadOnlyAddressBook {
         for (Sale s : sales.asUnmodifiableObservableList()) {
             if (s.getTags().contains(target)) {
                 Person buyer = persons.asUnmodifiableObservableList().stream()
-                        .filter(person -> person.equals(s.getBuyer()))
+                        .filter(person -> person.hasSameId(s.getBuyer()))
                         .findAny()
                         .orElse(null);
                 assert buyer != null;

--- a/src/main/java/seedu/address/model/meeting/UniqueMeetingList.java
+++ b/src/main/java/seedu/address/model/meeting/UniqueMeetingList.java
@@ -92,7 +92,7 @@ public class UniqueMeetingList implements Iterable<Meeting> {
     public void updateMeetingsWithContact(Person contact) {
         requireNonNull(contact);
         List<Meeting> meetingsToUpdate =
-                internalList.stream().filter(meeting -> meeting.getPersonId() == contact.getId())
+                internalList.stream().filter(meeting -> meeting.getPerson().hasSameId(contact))
                         .collect(Collectors.toList());
 
         for (Meeting meeting : meetingsToUpdate) {

--- a/src/main/java/seedu/address/model/person/Person.java
+++ b/src/main/java/seedu/address/model/person/Person.java
@@ -151,10 +151,17 @@ public class Person {
                 .append(" Email: ")
                 .append(getEmail())
                 .append(" Address: ")
-                .append(getAddress())
-                .append(" Tags: ");
-        getTags().forEach(builder::append);
-        builder.append(" Remark: ").append(getRemark());
+                .append(getAddress());
+
+        if (getTags().size() > 0) {
+            builder.append(" Tags: ");
+            getTags().forEach(builder::append);
+        }
+
+        if (!getRemark().isEmpty()) {
+            builder.append(" Remark: ").append(getRemark());
+        }
+
         return builder.toString();
     }
 

--- a/src/main/java/seedu/address/model/person/Person.java
+++ b/src/main/java/seedu/address/model/person/Person.java
@@ -93,6 +93,10 @@ public class Person {
         tags.remove(tag);
     }
 
+    public boolean hasSameId(Person otherPerson) {
+        return this.id.equals(otherPerson.id);
+    }
+
     /**
      * Returns true if both persons of the same name have at least one other identity field that is the same.
      * This defines a weaker notion of equality between two persons.
@@ -117,12 +121,19 @@ public class Person {
             return true;
         }
 
-        if (!(other instanceof Person)) {
+        if (!(other instanceof Person) || other == null) {
             return false;
         }
 
         Person otherPerson = (Person) other;
-        return this.id.equals(otherPerson.id);
+
+        return otherPerson.getId().equals(getId())
+                && otherPerson.getName().equals(getName())
+                && otherPerson.getPhone().equals(getPhone())
+                && otherPerson.getEmail().equals(getEmail())
+                && otherPerson.getAddress().equals(getAddress())
+                && otherPerson.getTags().equals(getTags())
+                && otherPerson.getRemark().equals(getRemark());
     }
 
     @Override

--- a/src/main/java/seedu/address/model/reminder/UniqueReminderList.java
+++ b/src/main/java/seedu/address/model/reminder/UniqueReminderList.java
@@ -81,7 +81,7 @@ public class UniqueReminderList implements Iterable<Reminder> {
     public void updateRemindersWithContact(Person contact) {
         requireNonNull(contact);
         List<Reminder> remindersToUpdate =
-                internalList.stream().filter(reminder -> reminder.getPersonId() == contact.getId())
+                internalList.stream().filter(reminder -> reminder.getPerson().hasSameId(contact))
                         .collect(Collectors.toList());
 
         for (Reminder reminder : remindersToUpdate) {

--- a/src/main/java/seedu/address/model/sale/UniqueSaleList.java
+++ b/src/main/java/seedu/address/model/sale/UniqueSaleList.java
@@ -132,7 +132,7 @@ public class UniqueSaleList implements Iterable<Sale> {
     public void updateSalesWithContact(Person buyer) {
         requireNonNull(buyer);
         List<Sale> salesToUpdate =
-                internalList.stream().filter(sale -> sale.getBuyer().getId() == buyer.getId())
+                internalList.stream().filter(sale -> sale.getBuyer().hasSameId(buyer))
                         .collect(Collectors.toList());
 
         for (Sale sale : salesToUpdate) {

--- a/src/test/java/seedu/address/logic/commands/tag/FindCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/tag/FindCommandTest.java
@@ -34,7 +34,7 @@ class FindCommandTest {
                 + "2. Benson Meier Phone: 98765432 Email: johnd@example.com "
                 + "Address: 311, Clementi Ave 2, #02-25 Tags: [owesMoney][friends] Remark: Owes me $10\n"
                 + "3. Daniel Meier Phone: 87652533 Email: cornelia@example.com "
-                + "Address: 10th street Tags: [friends] Remark: \n";
+                + "Address: 10th street Tags: [friends]\n";
 
         Model expectedModel = new ModelManager(new AddressBook(model.getAddressBook()), new UserPrefs());
         expectedModel.findByContactTag(tagToFind);

--- a/src/test/java/seedu/address/model/AddressBookTest.java
+++ b/src/test/java/seedu/address/model/AddressBookTest.java
@@ -132,7 +132,7 @@ public class AddressBookTest {
                 + "2. Benson Meier Phone: 98765432 Email: johnd@example.com "
                 + "Address: 311, Clementi Ave 2, #02-25 Tags: [owesMoney][friends] Remark: Owes me $10\n"
                 + "3. Daniel Meier Phone: 87652533 Email: cornelia@example.com "
-                + "Address: 10th street Tags: [friends] Remark: \n",
+                + "Address: 10th street Tags: [friends]\n",
                 addressBook.findByContactTag(TypicalContactTags.FRIENDS));
     }
 


### PR DESCRIPTION
Closes #198, closes #184 

**Changes made**
- Fix contact equality issues: there are now 3 methods checking for equality, hasSameId, isSamePerson, and equals
    - hasSameId is used to identify Persons belonging to Meetings/Remarks/Sales to edit when a Person is updated
    - isSamePerson is used to check for duplicated persons
    - equals (the strictest) verifies that the data and identity fields are identical.
- Clarify criteria for duplicate contact in UG
- Update toString method to only print "Tags" and "Remarks" if any
