### PR TITLE
Fix big index error bug

### DIFF
--- a/src/main/java/seedu/address/commons/core/Messages.java
+++ b/src/main/java/seedu/address/commons/core/Messages.java
@@ -25,8 +25,8 @@ public class Messages {
     public static final String MESSAGE_INVALID_MEETING_DISPLAYED_INDEX = "The meeting index provided is invalid.";
     public static final String MESSAGE_INVALID_SALE_DISPLAYED_INDEX = "The sale index(es) provided is invalid.";
     public static final String MESSAGE_EMPTY_DATASET = "There are no available statistics as there are no sale tags.";
-    public static final String MESSAGE_UNARCHIVE_INVALID_LIST = "Please list all archived persons first!";
-    public static final String MESSAGE_ARCHIVE_INVALID_LIST = "Please list all contacts first!";
+    public static final String MESSAGE_UNARCHIVE_INVALID_LIST = "The person is not archived!";
+    public static final String MESSAGE_ARCHIVE_INVALID_LIST = "The person is already archived!";
     public static final String MESSAGE_INVALID_MONTH =
             "Month must be an integer value in between 1 and 12 inclusive.";
     public static final String MESSAGE_INVALID_YEAR = "Year must be an non negative integer.";

--- a/src/main/java/seedu/address/commons/core/index/Index.java
+++ b/src/main/java/seedu/address/commons/core/index/Index.java
@@ -10,6 +10,7 @@ package seedu.address.commons.core.index;
  */
 public class Index {
     private int zeroBasedIndex;
+    private String inputIndex;
 
     /**
      * Index can only be created by calling {@link Index#fromZeroBased(int)} or
@@ -21,6 +22,12 @@ public class Index {
         }
 
         this.zeroBasedIndex = zeroBasedIndex;
+        this.inputIndex = String.valueOf(zeroBasedIndex + 1);
+    }
+
+    private Index(int zeroBasedIndex, String inputIndex) {
+        this.zeroBasedIndex = zeroBasedIndex;
+        this.inputIndex = inputIndex;
     }
 
     public int getZeroBased() {
@@ -29,6 +36,10 @@ public class Index {
 
     public int getOneBased() {
         return zeroBasedIndex + 1;
+    }
+
+    public String getOneBasedInString() {
+        return inputIndex;
     }
 
     /**
@@ -43,6 +54,13 @@ public class Index {
      */
     public static Index fromOneBased(int oneBasedIndex) {
         return new Index(oneBasedIndex - 1);
+    }
+
+    /**
+     * Creates a new {@code Index} to handle large unsupported indexes.
+     */
+    public static Index tooLargeIndex(String inputIndex) {
+        return new Index(Integer.MAX_VALUE, inputIndex);
     }
 
     @Override

--- a/src/main/java/seedu/address/commons/util/StringUtil.java
+++ b/src/main/java/seedu/address/commons/util/StringUtil.java
@@ -59,8 +59,16 @@ public class StringUtil {
         requireNonNull(s);
 
         try {
-            int value = Integer.parseInt(s);
-            return value > 0 && !s.startsWith("+"); // "+1" is successfully parsed by Integer#parseInt(String)
+            if (s.length() == 0) {
+                return false;
+            }
+            if (s.length() == 1 && s.charAt(0) == '0') {
+                return false;
+            }
+            for (int i = 0; i < s.length(); i++) {
+                Integer.parseInt(String.valueOf(s.charAt(i)));
+            }
+            return true;
         } catch (NumberFormatException nfe) {
             return false;
         }

--- a/src/main/java/seedu/address/logic/commands/sale/MassSaleCommandUtil.java
+++ b/src/main/java/seedu/address/logic/commands/sale/MassSaleCommandUtil.java
@@ -59,7 +59,7 @@ public class MassSaleCommandUtil {
         assert !invalidIndexes.isEmpty();
         StringBuilder listOfInvalidIndexes = new StringBuilder(message + ": ");
         for (Index invalidIndex : invalidIndexes) {
-            listOfInvalidIndexes.append(invalidIndex.getOneBased()).append(", ");
+            listOfInvalidIndexes.append(invalidIndex.getOneBasedInString()).append(", ");
         }
         String completedListOfInvalidIndexes = listOfInvalidIndexes.toString();
         return completedListOfInvalidIndexes.substring(0, completedListOfInvalidIndexes.length() - 2);

--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -10,6 +10,7 @@ import static seedu.address.commons.core.Messages.MESSAGE_INVALID_YEAR;
 import static seedu.address.logic.commands.sale.EditCommand.MESSAGES_SALES_MISSING_TAGS;
 
 import java.math.BigDecimal;
+import java.math.BigInteger;
 import java.time.DateTimeException;
 import java.time.Duration;
 import java.time.LocalDateTime;
@@ -72,6 +73,14 @@ public class ParserUtil {
         if (!StringUtil.isNonZeroUnsignedInteger(trimmedIndex)) {
             throw new ParseException(MESSAGE_INVALID_INDEX);
         }
+
+        // checks if the index is too big, i.e. greater than Integer.MAX_VALUE
+        try {
+            new BigInteger(trimmedIndex).intValueExact();
+        } catch (NumberFormatException | ArithmeticException e) {
+            return Index.tooLargeIndex(oneBasedIndex);
+        }
+
         return Index.fromOneBased(Integer.parseInt(trimmedIndex));
     }
 


### PR DESCRIPTION
Closes #204.

**Bug fixes**
- Fix archive add/remove command error messages to be consistent with the UG.
- Fix big index inputs (in particular values bigger than `Integer.MAX_VALUE`) triggering invalid format error instead of invalid index error. This is done by modifying the `parseIndex` and `isZeroUnsignedInteger` methods to handle unusually big index values. The `Index` class now remembers the input index string so that error messages can tell users the exact erroneous input indexes, especially for indexes greater than `Integer.MAX_VALUE`.

**Preview**
![bugg](https://user-images.githubusercontent.com/65291543/97894746-d65d1f80-1d6d-11eb-9b4b-10171571042d.png)
